### PR TITLE
fix: add NetBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ in {
 }
 ```
 
+### NetBSD
+```shell
+pkgin install matugen
+```
+or, if you prefer to build it from source
+```shell
+cd /usr/pkgsrc/graphics/matugen
+make install
+```
+
 ## Usage
 
 >**Note** For some reason the output of the colors is a bit weird in the gifs, here is how the output actually looks:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Matugen is a cross-platform tool that generates a colorscheme either from an ima
 - Windows
 - Linux
 - MacOS
->**Warning** Matugen only supports setting the wallpaper and restarting apps on Linux for now.
+- NetBSD
+>**Warning** Matugen only supports setting the wallpaper and restarting apps on Linux and NetBSD for now.
      
 ## Roadmap
 

--- a/src/util/reload.rs
+++ b/src/util/reload.rs
@@ -2,7 +2,7 @@ use super::{arguments::Cli, config::ConfigFile};
 use color_eyre::{eyre::Result, Report};
 use std::process::Command;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub fn reload_apps_linux(args: &Cli, config: &ConfigFile) -> Result<(), Report> {
     reload_app("kitty", "SIGUSR1")?;
     reload_app("waybar", "SIGUSR2")?;

--- a/src/util/wallpaper.rs
+++ b/src/util/wallpaper.rs
@@ -8,7 +8,7 @@ use super::{
     reload::reload_app,
 };
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub fn set_wallaper(config: &ConfigFile, args: &Cli) -> Result<(), Report> {
     let wallpaper_tool = match &config.config.wallpaper_tool {
         Some(wallpaper_tool) => wallpaper_tool,
@@ -32,7 +32,7 @@ pub fn set_wallaper(config: &ConfigFile, args: &Cli) -> Result<(), Report> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn set_wallaper_swaybg(path: &String) -> Result<(), Report> {
     reload_app("swaybg", "SIGUSR1")?;
 
@@ -45,7 +45,7 @@ fn set_wallaper_swaybg(path: &String) -> Result<(), Report> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn set_wallaper_swwww(config: &ConfigFile, path: &String) -> Result<(), Report> {
     let mut binding = Command::new("swww");
     let cmd = binding.stdout(Stdio::null()).stderr(Stdio::null());
@@ -62,7 +62,7 @@ fn set_wallaper_swwww(config: &ConfigFile, path: &String) -> Result<(), Report> 
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn set_wallaper_nitrogen(path: &String) -> Result<(), Report> {
     let mut binding = Command::new("nitrogen");
     let cmd = binding.stdout(Stdio::null()).stderr(Stdio::null());
@@ -72,7 +72,7 @@ fn set_wallaper_nitrogen(path: &String) -> Result<(), Report> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn set_wallaper_feh(config: &ConfigFile, path: &String) -> Result<(), Report> {
     let mut binding = Command::new("feh");
     let cmd = binding.stdout(Stdio::null()).stderr(Stdio::null());


### PR DESCRIPTION
Hi,

I've packaged `matugen` for NetBSD and will merge the package tomorrow morning, it's getting late here :)

Here it is running on my system,
![2023-08-05-224827_1366x768_scrot](https://github.com/InioX/Matugen/assets/90570748/43d0631c-45c3-4c6c-a6e9-5f0d40cdd1b7)

Please consider the patches provided allowing the build on NetBSD.

Some build warnings issued with Rust-1.71.1 you might already be aware of but, leaving them here anyway

```
   Compiling ini-material-color-utilities-rs v0.3.0 (/usr/pkgsrc/wip/matugen/work/Matugen-matugen-v0.8.3/material-color-utilities-rs)
warning: unused import: `linearized`
 --> material-color-utilities-rs/src/htc/cam16.rs:4:41
  |
4 | use crate::util::color::{argb_from_xyz, linearized, xyz_from_argb};
  |                                         ^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: associated function `new` is never used
   --> material-color-utilities-rs/src/htc/cam16.rs:119:8
    |
34  | impl Cam16 {
    | ---------- associated function in this implementation
...
119 |     fn new(
    |        ^^^
    |
    = note: `#[warn(dead_code)]` on by default

   Compiling paris-log v1.0.2
   Compiling resolve-path v0.1.0
   Compiling directories v5.0.1
   Compiling toml v0.7.3
warning: `ini-material-color-utilities-rs` (lib) generated 2 warnings (run `cargo fix --lib -p ini-material-color-utilities-rs` to apply 1 suggestion)
   Compiling pretty_env_logger v0.4.0
   Compiling colorsys v0.6.7
   Compiling matugen v0.8.3 (/usr/pkgsrc/wip/matugen/work/Matugen-matugen-v0.8.3)
warning: unused import: `ValueEnum`
 --> src/util/arguments.rs:1:48
  |
1 | use clap::{arg, ArgAction, Parser, Subcommand, ValueEnum};
  |                                                ^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `util::color::format_argb_as_rgb`
 --> src/util/color.rs:1:51
  |
1 | use material_color_utilities_rs::{scheme::Scheme, util::color::format_argb_as_rgb};
  |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `Color`
 --> src/main.rs:8:25
  |
8 |     color::{show_color, Color},
  |                         ^^^^^

warning: unused imports: `ColorTransform`, `SaturationInSpace`
  --> src/main.rs:24:28
   |
24 | use colorsys::{ColorAlpha, ColorTransform, Hsl, Rgb, SaturationInSpace};
   |                            ^^^^^^^^^^^^^^            ^^^^^^^^^^^^^^^^^

warning: unused import: `color`
  --> src/main.rs:27:12
   |
27 | use util::{color, reload::reload_apps_linux, wallpaper::set_wallaper};
   |            ^^^^^

warning: `matugen` (bin "matugen") generated 5 warnings (run `cargo fix --bin "matugen"` to apply 5 suggestions)
    Finished release [optimized] target(s) in 4m 06s
```