### PR TITLE
cli: add --json flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -736,6 +736,7 @@ dependencies = [
  "regex",
  "resolve-path",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -976,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -1000,9 +1001,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1145,22 +1146,33 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1212,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1258,7 +1270,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ log = "0.4.17"
 paris-log = { version = "1.0.2", features = ["icons"] }
 colorsys = "0.6.7"
 prettytable-rs = "0.10.0"
+serde_json = "1.0.107"
 
 [workspace]
 members = ["material-color-utilities-rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate paris_log;
 mod util;
 use crate::util::{
     arguments::Cli,
-    color::{get_source_color, show_color},
+    color::{dump_json, get_source_color, show_color},
     config::ConfigFile,
     template::Template,
 };
@@ -80,6 +80,10 @@ fn main() -> Result<(), Report> {
 
     if args.show_colors == Some(true) {
         show_color(&schemes, &source_color);
+    }
+
+    if let Some(format) = args.json {
+        dump_json(&schemes, &source_color, format);
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate paris_log;
 mod util;
 use crate::util::{
     arguments::Cli,
-    color::{show_color, get_source_color},
+    color::{get_source_color, show_color},
     config::ConfigFile,
     template::Template,
 };
@@ -42,7 +42,7 @@ pub enum SchemesEnum {
 fn main() -> Result<(), Report> {
     color_eyre::install()?;
     let args = Cli::parse();
-    
+
     setup_logging(&args)?;
 
     let source_color = get_source_color(&args.source)?;
@@ -51,26 +51,21 @@ fn main() -> Result<(), Report> {
 
     let config: ConfigFile = ConfigFile::read(&args)?;
 
-    let default_scheme = args.mode.expect("Something went wrong while parsing the mode");
+    let default_scheme = args
+        .mode
+        .expect("Something went wrong while parsing the mode");
 
     let schemes: Schemes = Schemes {
         light: Scheme::light_from_core_palette(&mut palette),
         dark: Scheme::dark_from_core_palette(&mut palette),
         amoled: Scheme::pure_dark_from_core_palette(&mut palette),
-        light_android: SchemeAndroid::light_from_core_palette(&mut palette), 
+        light_android: SchemeAndroid::light_from_core_palette(&mut palette),
         dark_android: SchemeAndroid::dark_from_core_palette(&mut palette),
         amoled_android: SchemeAndroid::pure_dark_from_core_palette(&mut palette),
     };
 
-
     if args.dry_run == Some(false) {
-        Template::generate(
-            &schemes,
-            &config,
-            &args,
-            &source_color,
-            &default_scheme,
-        )?;
+        Template::generate(&schemes, &config, &args, &source_color, &default_scheme)?;
 
         if config.config.reload_apps == Some(true) {
             reload_apps_linux(&args, &config)?;

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -51,6 +51,17 @@ pub struct Cli {
     /// Whether to show colors or not
     #[arg(long, global = true, action=ArgAction::SetTrue, default_value = "false")]
     pub show_colors: Option<bool>,
+
+    /// Whether to dump json of colors
+    #[arg(
+        value_enum,
+        short,
+        long,
+        global = true,
+        value_name = "JSON",
+        default_value = None,
+    )]
+    pub json: Option<Format>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -67,4 +78,14 @@ pub enum ColorFormat {
     Hex { string: String },
     Rgb { string: String },
     Hsl { string: String },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum Format {
+    Hex,
+    Rgb,
+    Rgba,
+    Hsl,
+    Hsla,
+    Strip,
 }

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -34,7 +34,14 @@ pub struct Cli {
     pub quiet: Option<bool>,
 
     /// Which mode to use for the color scheme
-    #[arg(value_enum, short, long, global = true, value_name = "MODE", default_value = "dark")]
+    #[arg(
+        value_enum,
+        short,
+        long,
+        global = true,
+        value_name = "MODE",
+        default_value = "dark"
+    )]
     pub mode: Option<SchemesEnum>,
 
     /// Will not generate templates, reload apps, set wallpaper or run any commands


### PR DESCRIPTION
This new flag allows for dumping the schemes similarly to `--show-colors`, but in a machine-readable format. Can dump hex, stripped hex, rgb, rgba, hsl, hsla.

The structure of the json looks like this:

```json
{
  "colors": {
    "light": {scheme},
    "dark": {scheme},
    "amoled": {scheme}
  },
  "colors_android": {
    "light": {scheme},
    "dark": {scheme},
    "amoled": {scheme}
  }
}
```
