### PR TITLE
nix: support for aarch64 + overridable systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -24,16 +24,16 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1680978846,
-        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
-        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
+        "repo": "default-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = " A material you color generation tool for linux ";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    systems.url = "github:nix-systems/x86_64-linux";
+    systems.url = "github:nix-systems/default-linux";
   };
   outputs = { self, nixpkgs, systems }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   description = " A material you color generation tool for linux ";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/x86_64-linux";
   };
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, systems }:
     let
-      supportedSystems = [ "x86_64-linux" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      forAllSystems = nixpkgs.lib.genAttrs (import systems);
       pkgsFor = nixpkgs.legacyPackages;
     in {
       packages = forAllSystems (system: {


### PR DESCRIPTION
Hi! I'm trying out matugen in my quest to find a better theming solution than base16, been loving it so far!

I want to use this in an `aarch64-linux` machine, so adding it to `supportedSystems` would be nice. An even better solution is to use `nix-systems`, which allows flake consumers to override `systems` without forking this flake.

https://github.com/InioX/matugen/commit/98db97f610f2c9ae1cdd96f1d94667bff496b3d5 simply adds `nix-systems`, but keeps the default `x86_64-linux` only (by using `github:nix-systems/x86_64-linux`).

https://github.com/InioX/matugen/commit/1074f55d5e7b95824fae2dd1cc3ad501bd6f00b1 adds support to `aarch64-linux` by changing `systems` to `github:nix-systems/default-linux`

Feel free to merge either both or just the first one, depending on if you want to officially support ARM or not.

Thanks!