### PR TITLE
Rework harmonized colors into custom colors

### DIFF
--- a/example/config.toml
+++ b/example/config.toml
@@ -14,7 +14,7 @@ test = "aaaa"
 input_path = "example/colors.whatever-extension"
 output_path = "example/a/colors-generated.whatever-extension"
 
-[config.colors_to_harmonize]
+[config.custom_colors]
 green = "#00FF00"
 red = "#FF0000"
-blue = "#0000FF"
+blue = { color = "#0000FF", blend = false }

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -1,4 +1,5 @@
 use directories::ProjectDirs;
+use material_colors::{argb_from_hex, utils::string::ParseError};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -19,6 +20,33 @@ pub enum WallpaperTool {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum CustomColor {
+    Color(String),
+    Options { color: String, blend: bool },
+}
+
+impl CustomColor {
+    pub fn to_custom_color(
+        &self,
+        name: String,
+    ) -> Result<material_colors::utils::theme::CustomColor, ParseError> {
+        Ok(match self {
+            CustomColor::Color(color) => material_colors::utils::theme::CustomColor {
+                value: argb_from_hex(color)?,
+                blend: true,
+                name,
+            },
+            CustomColor::Options { color, blend } => material_colors::utils::theme::CustomColor {
+                value: argb_from_hex(color)?,
+                blend: *blend,
+                name,
+            },
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub reload_apps: Option<bool>,
     pub reload_apps_list: Option<Apps>,
@@ -29,7 +57,7 @@ pub struct Config {
     pub feh_options: Option<Vec<String>>,
     pub prefix: Option<String>,
     pub custom_keywords: Option<HashMap<String, String>>,
-    pub colors_to_harmonize: Option<HashMap<String, String>>,
+    pub custom_colors: Option<HashMap<String, CustomColor>>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/util/template.rs
+++ b/src/util/template.rs
@@ -95,7 +95,6 @@ impl Template {
         source_color: &[u8; 4],
         default_scheme: &SchemesEnum,
         custom_keywords: &Option<HashMap<String, String>>,
-        harmonized_colors: &Option<HashMap<String, [u8; 4]>>,
     ) -> Result<(), Report> {
         let default_prefix = "@".to_string();
 
@@ -124,8 +123,6 @@ impl Template {
 
         let colors = generate_colors(schemes, source_color, default_scheme)?;
 
-        let harmonized = generate_harmonized_colors(source_color, harmonized_colors)?;
-
         let mut custom: HashMap<String, String> = Default::default();
 
         for entry in custom_keywords.iter() {
@@ -135,7 +132,7 @@ impl Template {
         }
 
         let render_data = upon::value! {
-            colors: &colors, image: image, custom: &custom, harmonized_colors: harmonized,
+            colors: &colors, image: image, custom: &custom,
         };
 
         // debug!("render_data: {:#?}", &render_data);
@@ -243,21 +240,6 @@ fn generate_colors(
         generate_single_color("source_color", schemes, source_color, default_scheme)?,
     );
     Ok(hashmap)
-}
-
-fn generate_harmonized_colors(
-    _source_color: &[u8; 4],
-    harmonized_colors: &Option<HashMap<String, [u8; 4]>>,
-) -> Result<Option<HashMap<String, Colora>>, Report> {
-    if let Some(colors) = harmonized_colors {
-        let mut map: HashMap<String, Colora> = Default::default();
-        for (name, color) in colors {
-            map.insert(name.to_string(), generate_color_strings(*color));
-        }
-        Ok(Some(map))
-    } else {
-        Ok(None)
-    }
 }
 
 fn generate_single_color(


### PR DESCRIPTION
Fixes https://github.com/InioX/matugen/issues/63

This PR reworks the recent addition of harmonized colors into a more fleshed out custom color system with proper blending and dark/light support.

This does break older harmonized color configs, however considering how new that feature was (and also the lack of documentation) I think a breaking change here is for the better.

Custom colors can be configured like this
```toml
[config.custom_colors]
red = "#ff0000"
blue = "#0000ff"
green = "#00ff00"
```

Output

| NAME | LIGHT | DARK |
| ---  | --- | ---- |
| blue_source                | `#0000FF` |        `#0000FF`       
| blue_value                 | `#0000FF` |        `#0000FF`     
| blue                       | `#265BB7` |        `#AFC6FF`       
| on_blue                    | `#FFFFFF` |        `#002D6D`       
| blue_container             | `#D9E2FF` |        `#004299`       
| on_blue_container          | `#001944` |        `#D9E2FF`       
| red_source                 | `#FF0000` |        `#FF0000`       
| red_value                  | `#FF0000` |        `#FF0000`       
| red                        | `#A23F00` |        `#FFB595`       
| on_red                     | `#FFFFFF` |        `#571E00`       
| red_container              | `#FFDBCD` |        `#7C2E00`       
| on_red_container           | `#350F00` |       `#FFDBCD`       
| green_source               | `#00FF00` |        `#00FF00`       
| green_value                | `#00FF00` |        `#00FF00`       
| green                      | `#006D3D` |        `#00E385`       
| on_green                   | `#FFFFFF` |        `#00391D`       
| green_container            | `#5AFFA2` |        `#00522C`       
| on_green_container         | `#00210F` |        `#5AFFA2` 

By default these are also harmonized with the source color. This can be turned off per-color like this 
```toml
[config.custom_colors]
red = { color = "#ff0000", blend = false }
```

Blend: `#6A2FEE`, no blend: `#343DFF`


This PR also fixes harmonized colors not showing with the `--show-colors` flag.

The custom colors are added to the default colors and can be used like you'd expect

```
{{colors.red.default.hex}}
```

| Harmonized Colors | This PR |
| ---- | ---- |
| ![image](https://github.com/InioX/matugen/assets/19289296/61ec6dd0-0fb7-4dde-a8ec-f8f52ffd1646) | ![image](https://github.com/InioX/matugen/assets/19289296/1b61ea46-7026-4d35-beff-b1eea4097314) |
| ![image](https://github.com/InioX/matugen/assets/19289296/16b020c7-6034-4a1e-820d-3958eb32f586) | ![image](https://github.com/InioX/matugen/assets/19289296/07ea5e0a-c9a0-42b0-8891-9889599f1e43) |


Possible TODOs:
* ~~Make these react to the theme variants?~~ Done
* ~~Make these react to the contrast preferences?~~ Done
* Add more accent variants, shade/tint that get darker/lighter depending on the mode?



