### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-06-29
+
+### Added
+- fix relative paths for templates, format `compare_to` ([#83](https://github.com/InioX/matugen/pull/83))
+- add template formatting for hook ([#83](https://github.com/InioX/matugen/pull/83))
+- add `hook` and variables inside it ([#83](https://github.com/InioX/matugen/pull/83))
+- add color comparsion ([#83](https://github.com/InioX/matugen/pull/83))
+- add `--prefix` argument
+- add `version_check` setting ([#78](https://github.com/InioX/matugen/pull/78))
+
+### Fixed
+- update arguments to remove borrow error ([#85](https://github.com/InioX/matugen/pull/85))
+- update syntax in example template ([#77](https://github.com/InioX/matugen/pull/77))
+
+### Other
+- rename `compared_color` to `closest_color`
+- separate some stuff into functions
+- format code
+- Merge branch 'main' of https://github.com/InioX/matugen
+- run `cargo fmt`
+- *(readme)* update version badges
+
 ## [2.3.0](https://github.com/InioX/matugen/compare/v2.2.0...v2.3.0) - 2024-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "ahash",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["InioX"]
 description = "A material you color generation tool with templates"
 repository = "https://github.com/InioX/matugen"

--- a/example/config.toml
+++ b/example/config.toml
@@ -30,7 +30,7 @@ colors_to_compare = [
     { name = "purple", color = "#800080" },
 ]
 compare_to = "{{colors.primary.default.hex}}"
-hook = 'echo "source color {{colors.source_color.default.hex}}, source image {{image}}, compared color {{compared_color}}"'
+hook = 'echo "source color {{colors.source_color.default.hex}}, source image {{image}}, closest color {{closest_color}}"'
 
 [config.custom_colors]
 green = "#00FF00"

--- a/src/util/template.rs
+++ b/src/util/template.rs
@@ -314,7 +314,7 @@ fn format_hook(
     engine: &Engine,
     render_data: &mut Value,
 ) -> Result<(), Report> {
-    let compared_color: Option<String> =
+    let closest_color: Option<String> =
         if template.colors_to_compare.is_some() && template.compare_to.is_some() {
             let s = engine.compile(template.compare_to.as_ref().unwrap())?;
             let compare_to = s.render(&engine, &render_data).to_string()?;
@@ -328,7 +328,7 @@ fn format_hook(
     Ok(
         if template.colors_to_compare.is_some() && template.compare_to.is_some() {
             let t = engine.compile(template.hook.as_ref().unwrap())?;
-            let res = format_hook_text(render_data, compared_color.as_ref(), t);
+            let res = format_hook_text(render_data, closest_color.as_ref(), t);
             let mut command = shell(&res);
 
             command.stdout(Stdio::inherit());

--- a/src/util/variables.rs
+++ b/src/util/variables.rs
@@ -18,7 +18,7 @@ use upon::{Engine, Syntax, Template, Value};
 //         }
 
 //         match input {
-//             "compared_color" => Variables::ComparedColor,
+//             "closest_color" => Variables::ComparedColor,
 //             "source_image" => Variables::SourceImage,
 //             "source_color" => Variables::SourceColor,
 //             _ => {
@@ -53,7 +53,7 @@ use upon::{Engine, Syntax, Template, Value};
 //     input: &str,
 //     default_value: &String,
 //     src_img: Option<&String>,
-//     compared_color: Option<&String>,
+//     closest_color: Option<&String>,
 //     source_color: &Argb,
 // ) -> String {
 //     let re = Regex::new(r"\{.*?\}").unwrap();
@@ -63,7 +63,7 @@ use upon::{Engine, Syntax, Template, Value};
 //     let result = re.replace_all(input, |cap: &Captures| {
 //         match Variables::from(&cap[0]) {
 //             Variables::Invalid => &cap[0],
-//             Variables::ComparedColor => compared_color.unwrap_or(default_value),
+//             Variables::ComparedColor => closest_color.unwrap_or(default_value),
 //             Variables::SourceImage => src_img.unwrap_or(default_value),
 //             Variables::SourceColor => &source_formatted,
 //         }
@@ -73,13 +73,13 @@ use upon::{Engine, Syntax, Template, Value};
 //     return result.to_string();
 // }
 
-pub fn format_hook_text(render_data: &mut Value, compared_color: Option<&String>, template: Template<'_>) -> String {
+pub fn format_hook_text(render_data: &mut Value, closest_color: Option<&String>, template: Template<'_>) -> String {
     let syntax = Syntax::builder().expr("{{", "}}").block("<*", "*>").build();
     let mut engine = Engine::with_syntax(syntax);
     match render_data {
         Value::Map(ref mut map) => {
-            if compared_color.is_some() {
-                map.insert("compared_color".to_string(), Value::from(compared_color.unwrap().as_str()));
+            if closest_color.is_some() {
+                map.insert("closest_color".to_string(), Value::from(closest_color.unwrap().as_str()));
             }
         },
         _ => {


### PR DESCRIPTION
## 🤖 New release
* `matugen`: 2.3.0 -> 2.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-06-29

### Added
- fix relative paths for templates, format `compare_to` ([#83](https://github.com/InioX/matugen/pull/83))
- add template formatting for hook ([#83](https://github.com/InioX/matugen/pull/83))
- add `hook` and variables inside it ([#83](https://github.com/InioX/matugen/pull/83))
- add color comparsion ([#83](https://github.com/InioX/matugen/pull/83))
- add `--prefix` argument
- add `version_check` setting ([#78](https://github.com/InioX/matugen/pull/78))

### Fixed
- update arguments to remove borrow error ([#85](https://github.com/InioX/matugen/pull/85))
- update syntax in example template ([#77](https://github.com/InioX/matugen/pull/77))

### Other
- rename `compared_color` to `closest_color`
- separate some stuff into functions
- format code
- Merge branch 'main' of https://github.com/InioX/matugen
- run `cargo fmt`
- *(readme)* update version badges
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).