### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-08-13
+
+### Added
+- add `pre_hook` and `post_hook`
+- improve error message for color parsing
+- change resize filter to Lanczos3 ([#89](https://github.com/InioX/matugen/pull/89))
+- increase windows stack size to 8mb (fixes [#87](https://github.com/InioX/matugen/pull/87))
+- fix relative paths for templates, format `compare_to` ([#83](https://github.com/InioX/matugen/pull/83))
+- add template formatting for hook ([#83](https://github.com/InioX/matugen/pull/83))
+- add `hook` and variables inside it ([#83](https://github.com/InioX/matugen/pull/83))
+- add color comparsion ([#83](https://github.com/InioX/matugen/pull/83))
+- add `--prefix` argument
+- add `version_check` setting ([#78](https://github.com/InioX/matugen/pull/78))
+
+### Fixed
+- wrong display of alpha channel for `set_alpha` ([#95](https://github.com/InioX/matugen/pull/95))
+- divide all alpha values by 255 for output ([#95](https://github.com/InioX/matugen/pull/95))
+- set_alpha missing a `:` in example ([#95](https://github.com/InioX/matugen/pull/95))
+- make hooks not depend on `colors_to_compare` ([#93](https://github.com/InioX/matugen/pull/93))
+- remove useless debugging
+- update arguments to remove borrow error ([#85](https://github.com/InioX/matugen/pull/85))
+- update syntax in example template ([#77](https://github.com/InioX/matugen/pull/77))
+
+### Other
+- oops bad merge ([#95](https://github.com/InioX/matugen/pull/95))
+- Merge branch 'main' of https://github.com/InioX/matugen
+- add float parameter for `format_hsla` and `format_rgba` ([#95](https://github.com/InioX/matugen/pull/95))
+- update CHANGELOG.md
+- add set_alpha filter example
+- add the set_alpha filter to the engine
+- add format_rgba_float and format_hsla_float functions to format the alpha value as a float instead of u8
+- add set_alpha filter
+- Nix module: add package option
+- Merge branch 'main' of https://github.com/InioX/matugen
+- bump `material-colors` to 0.4.0
+- *(examples)* add note for `custom_colors`
+- rename `compared_color` to `closest_color` ([#83](https://github.com/InioX/matugen/pull/83))
+- separate some stuff into functions
+- format code
+- Merge branch 'main' of https://github.com/InioX/matugen
+- run `cargo fmt`
+- *(readme)* update version badges
+
 ### Added
 - add `set_alpha` filter
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "ahash",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["InioX"]
 description = "A material you color generation tool with templates"
 repository = "https://github.com/InioX/matugen"

--- a/example/config.toml
+++ b/example/config.toml
@@ -30,7 +30,8 @@ colors_to_compare = [
     { name = "purple", color = "#800080" },
 ]
 compare_to = "{{colors.primary.default.hex}}"
-hook = 'echo "source color {{colors.source_color.default.hex}}, source image {{image}}, closest color {{closest_color}}"'
+pre_hook = 'echo "source color {{colors.source_color.default.hex}}, source image {{image}}, closest color {{closest_color}}"'
+post_hook = 'echo "after gen"'
 
 # Only hex values
 [config.custom_colors]


### PR DESCRIPTION
## 🤖 New release
* `matugen`: 2.3.0 -> 2.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-08-13

### Added
- add `pre_hook` and `post_hook`
- improve error message for color parsing
- change resize filter to Lanczos3 ([#89](https://github.com/InioX/matugen/pull/89))
- increase windows stack size to 8mb (fixes [#87](https://github.com/InioX/matugen/pull/87))
- fix relative paths for templates, format `compare_to` ([#83](https://github.com/InioX/matugen/pull/83))
- add template formatting for hook ([#83](https://github.com/InioX/matugen/pull/83))
- add `hook` and variables inside it ([#83](https://github.com/InioX/matugen/pull/83))
- add color comparsion ([#83](https://github.com/InioX/matugen/pull/83))
- add `--prefix` argument
- add `version_check` setting ([#78](https://github.com/InioX/matugen/pull/78))

### Fixed
- wrong display of alpha channel for `set_alpha` ([#95](https://github.com/InioX/matugen/pull/95))
- divide all alpha values by 255 for output ([#95](https://github.com/InioX/matugen/pull/95))
- set_alpha missing a `:` in example ([#95](https://github.com/InioX/matugen/pull/95))
- make hooks not depend on `colors_to_compare` ([#93](https://github.com/InioX/matugen/pull/93))
- remove useless debugging
- update arguments to remove borrow error ([#85](https://github.com/InioX/matugen/pull/85))
- update syntax in example template ([#77](https://github.com/InioX/matugen/pull/77))

### Other
- oops bad merge ([#95](https://github.com/InioX/matugen/pull/95))
- Merge branch 'main' of https://github.com/InioX/matugen
- add float parameter for `format_hsla` and `format_rgba` ([#95](https://github.com/InioX/matugen/pull/95))
- update CHANGELOG.md
- add set_alpha filter example
- add the set_alpha filter to the engine
- add format_rgba_float and format_hsla_float functions to format the alpha value as a float instead of u8
- add set_alpha filter
- Nix module: add package option
- Merge branch 'main' of https://github.com/InioX/matugen
- bump `material-colors` to 0.4.0
- *(examples)* add note for `custom_colors`
- rename `compared_color` to `closest_color` ([#83](https://github.com/InioX/matugen/pull/83))
- separate some stuff into functions
- format code
- Merge branch 'main' of https://github.com/InioX/matugen
- run `cargo fmt`
- *(readme)* update version badges

### Added
- add `set_alpha` filter
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).