### PR TITLE
Fix nix module package default option

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -57,12 +57,11 @@ in {
   options.programs.matugen = {
     enable = lib.mkEnableOption "Matugen declarative theming";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkg;
-      example = "pkgs.matugen";
-      description = "The matugen package to use.";
-    };
+    package =
+      lib.mkPackageOption pkgs "matugen" {}
+      // {
+        default = pkg;
+      };
 
     wallpaper = lib.mkOption {
       description = "Path to `wallpaper` that matugen will generate the colorschemes from";

--- a/module.nix
+++ b/module.nix
@@ -57,8 +57,11 @@ in {
   options.programs.matugen = {
     enable = lib.mkEnableOption "Matugen declarative theming";
 
-    package = lib.mkPackageOption pkgs "matugen" {
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkg;
+      example = "pkgs.matugen";
+      description = "The matugen package to use.";
     };
 
     wallpaper = lib.mkOption {


### PR DESCRIPTION
mkPackageOption doesn't work with a set:
```
… while evaluating the option `home-manager.users.amadejk.programs.matugen.theme.colors':
… while evaluating the option `home-manager.users.amadejk.programs.matugen.package':
(stack trace truncated; use '--show-trace' to show the full, detailed trace)
error: expected a string but found a set: { type = "derivation"; PKG_CONFIG_ALLOW_CROSS = «thunk»; __ignoreNulls = true; __structuredAttrs = «thunk»; all = «thunk»; args = «thunk»; buildAndTestSubdir = null; buildInputs = «thunk»; builder = «thunk»; cargoBuildFeatures = [ ]; «46 attributes elided» }
```