### PR TITLE
Add Options to Nix Module

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -40,7 +40,7 @@ matugen: {
   matugenConfig = configFormat.generate "matugen-config.toml" {
     config = {
       custom_colors = cfg.custom_colors;
-    };
+    } // cfg.config;
     templates = sanitizedTemplates;
   };
 
@@ -155,6 +155,17 @@ in {
       type = lib.types.enum ["light" "dark" "amoled"];
       default = osCfg.variant or "dark";
       example = "light";
+    };
+
+    config = lib.mkOption {
+      description = "Add things to the config not covered by other options.";
+      type = lib.types.attrs;
+      default = osCfg.config or {};
+      example = ''
+        {
+          custom_keywords.font1 = "Google Sans";
+        }
+      '';
     };
 
     theme.files = lib.mkOption {

--- a/module.nix
+++ b/module.nix
@@ -76,6 +76,7 @@ matugen: {
       --mode ${cfg.variant} \
       --type ${cfg.type} \
       --json ${cfg.jsonFormat} \
+      --contrast ${lib.strings.floatToString cfg.contrast} \
       --quiet \
       > $out/theme.json
   '');
@@ -180,6 +181,13 @@ in {
       type = lib.types.enum ["light" "dark" "amoled"];
       default = osCfg.variant or "dark";
       example = "light";
+    };
+
+    contrast = lib.mkOption {
+      description = "Value from -1 to 1. -1 represents minimum contrast, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum contrast.";
+      type = lib.types.numbers.between (-1) 1;
+      default = 0;
+      example = "0.2";   
     };
 
     config = lib.mkOption {


### PR DESCRIPTION
This PR is basically taking things that matugen can already do and adding support for them in the nix module. First commit adds support for extending the set of colours generated to include custom colours, second commit allows a fallback for the user to add things to the config without an explicit option for it (so that in between you adding a feature and adding an option for it, its still *usable* in the module if people want), and the final commit allows users to generate their colour scheme from a hex/rgb/hsl colour.