### PR TITLE
feat(filter): add camel_case filter and auto_lightness filter

### DIFF
--- a/src/filters/camel.rs
+++ b/src/filters/camel.rs
@@ -1,0 +1,27 @@
+use upon::Value;
+
+use crate::color::parse::check_string_value;
+
+pub fn camel_case(value: &Value) -> Result<String, String> {
+    let string = check_string_value(value).unwrap();
+
+    let mut result = String::new();
+    let mut capitalize_next = false;
+
+    for c in string.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else {
+            if capitalize_next {
+                result.push(c.to_uppercase().next().unwrap());
+                capitalize_next = false;
+            } else {
+                result.push(c);
+            }
+        }
+    }
+
+    debug!("Converting to camelCase: {} to {}", string, result);
+
+    Ok(result)
+}

--- a/src/filters/lightness.rs
+++ b/src/filters/lightness.rs
@@ -8,6 +8,73 @@ use crate::color::{
     parse::{check_string_value, parse_color},
 };
 
+fn adjust_rgb_lightness(color: &mut Rgb, amount: f64, threshold: f64) {
+    let hsl = Hsl::from(color.clone()); // Convert RGB to HSL
+
+    // Adjust lightness based on the threshold
+    if hsl.lightness() < threshold {
+        color.lighten(amount); // Increase lightness
+    } else {
+        color.lighten(-amount); // Decrease lightness
+    }
+}
+
+fn adjust_hsl_lightness(color: &mut Hsl, amount: f64, threshold: f64) {
+    // Adjust lightness based on the threshold
+    if color.lightness() < threshold {
+        color.lighten(amount); // Increase lightness
+    } else {
+        color.lighten(-amount); // Decrease lightness
+    }
+}
+
+pub fn auto_lightness(value: &Value, amount: f64) -> Result<String, String> {
+    let string = check_string_value(value).unwrap();
+    let threshold = 50.0;
+
+    let format = parse_color(string);
+
+    debug!("Setting lightness on string {} by {}", string, amount);
+
+    if format.is_none() {
+        return Ok(string.to_string());
+    }
+
+    match format.unwrap() {
+        "hex" => {
+            let mut color = Rgb::from_hex_str(string).unwrap();
+            adjust_rgb_lightness(&mut color, amount, threshold);
+            Ok(format_hex(&color))
+        }
+        "hex_stripped" => {
+            let mut color = Rgb::from_hex_str(string).unwrap();
+            adjust_rgb_lightness(&mut color, amount, threshold);
+            Ok(format_hex_stripped(&color))
+        }
+        "rgb" => {
+            let mut color = Rgb::from_str(string).unwrap();
+            adjust_rgb_lightness(&mut color, amount, threshold);
+            Ok(format_rgb(&color))
+        }
+        "rgba" => {
+            let mut color = Rgb::from_str(string).unwrap();
+            adjust_rgb_lightness(&mut color, amount, threshold);
+            Ok(format_rgba(&color, true))
+        }
+        "hsl" => {
+            let mut color = Hsl::from_str(string).unwrap();
+            adjust_hsl_lightness(&mut color, amount, threshold);
+            Ok(format_hsl(&color))
+        }
+        "hsla" => {
+            let mut color = Hsl::from_str(string).unwrap();
+            adjust_hsl_lightness(&mut color, amount, threshold);
+            Ok(format_hsla(&color, true))
+        }
+        v => Ok(v.to_string()),
+    }
+}
+
 pub fn set_lightness(value: &Value, amount: f64) -> Result<String, String> {
     let string = check_string_value(value).unwrap();
 

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,4 +1,5 @@
 pub mod alpha;
+pub mod camel;
 pub mod grayscale;
 pub mod hue;
 pub mod invert;

--- a/src/template_util/template.rs
+++ b/src/template_util/template.rs
@@ -14,7 +14,7 @@ use crate::filters::camel::camel_case;
 use crate::filters::grayscale::grayscale;
 use crate::filters::hue::set_hue;
 use crate::filters::invert::invert;
-use crate::filters::lightness::set_lightness;
+use crate::filters::lightness::{auto_lightness, set_lightness};
 use crate::scheme::{Schemes, SchemesEnum};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -44,6 +44,7 @@ pub struct ColorVariants {
 pub fn add_engine_filters(engine: &mut Engine) {
     // Color manipulation
     engine.add_filter("set_lightness", set_lightness);
+    engine.add_filter("auto_lightness", auto_lightness);
     engine.add_filter("set_alpha", set_alpha);
     engine.add_filter("set_hue", set_hue);
     engine.add_filter("grayscale", grayscale);

--- a/src/template_util/template.rs
+++ b/src/template_util/template.rs
@@ -10,6 +10,7 @@ use crate::color::format::{
     rgb_from_argb,
 };
 use crate::filters::alpha::set_alpha;
+use crate::filters::camel::camel_case;
 use crate::filters::grayscale::grayscale;
 use crate::filters::hue::set_hue;
 use crate::filters::invert::invert;
@@ -54,6 +55,7 @@ pub fn add_engine_filters(engine: &mut Engine) {
     engine.add_filter("replace", |s: String, from: String, to: String| {
         s.replace(&from, &to)
     });
+    engine.add_filter("camel_case", camel_case);
 }
 
 pub fn render_template(


### PR DESCRIPTION
Add camel_case filter
```
primary_container -> primaryContainer
secondary_container -> secondaryContainer
```
Usage
```
<* for name, value in colors *>
${{name | camel_case}}: {{value.default.hex}};
<* endfor *>
```


Add auto_lightness filter

- #ff0000 as hex color input gives 
    - (light to dark)
      `{{ colors.primary_container.default.hex }}` gives `#ffdad4`
      `{{ colors.primary_container.default.hex | auto_lightness: 20.0 }}` gives `#ff826e`
    - (dark to light)
      `{{ colors.primary_container.default.hex }}` gives `#73342a`
      `{{ colors.primary_container.default.hex | auto_lightness: 20.0 }}` gives `#bc5747`