### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0](https://github.com/InioX/matugen/compare/v2.4.0...v2.5.0) - 2024-11-13
+
+### Added
+
+- add `dump-json` to default features
+
+### Other
+
+- *(readme)* add discord server link
+
 ## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-11-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ winapi = { version = "0.3", features = ["winuser"] }
 enquote = "1.1.0"
 
 [features]
+default = ["dump-json"]
 update-informer = ["dep:update-informer"]
 web-image = ["dep:reqwest"]
 dump-json = ["dep:serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["InioX"]
 description = "A material you color generation tool with templates"
 repository = "https://github.com/InioX/matugen"


### PR DESCRIPTION
## 🤖 New release
* `matugen`: 2.4.0 -> 2.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.5.0](https://github.com/InioX/matugen/compare/v2.4.0...v2.5.0) - 2024-11-13

### Added

- add `dump-json` to default features

### Other

- *(readme)* add discord server link
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).