### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0](https://github.com/InioX/matugen/compare/v2.4.0...v2.5.0) - 2024-11-13
+
+### Added
+
+- remove `wallpaper.set` option
+
+### Fixed
+
+- add `dump-json` to default featues
+
+### Other
+
+- run cargo fmt
+- *(readme)* add discord server link
+
 ## [2.4.0](https://github.com/InioX/matugen/compare/v2.3.0...v2.4.0) - 2024-11-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["InioX"]
 description = "A material you color generation tool with templates"
 repository = "https://github.com/InioX/matugen"

--- a/example/config.toml
+++ b/example/config.toml
@@ -4,7 +4,6 @@
 [config.wallpaper]
 command = "swww"
 arguments = ["img", "--transition-type", "center"]
-set = true
 # pre_hook = ""
 
 [config.custom_keywords]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -63,7 +63,7 @@ pub fn set_wallpaper(source: &Source, wallpaper_cfg: wallpaper::Wallpaper) -> Re
         #[cfg(feature = "web-image")]
         Source::WebImage { .. } => return Ok(()),
     };
-    
+
     #[cfg(target_os = "windows")]
     wallpaper::windows::set(path)?;
     #[cfg(target_os = "macos")]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -63,11 +63,7 @@ pub fn set_wallpaper(source: &Source, wallpaper_cfg: wallpaper::Wallpaper) -> Re
         #[cfg(feature = "web-image")]
         Source::WebImage { .. } => return Ok(()),
     };
-    if !wallpaper_cfg.set {
-        return Ok(warn!(
-            "<d>Wallpaper setting disabled, not setting wallpaper...</>"
-        ));
-    };
+    
     #[cfg(target_os = "windows")]
     wallpaper::windows::set(path)?;
     #[cfg(target_os = "macos")]

--- a/src/wallpaper/mod.rs
+++ b/src/wallpaper/mod.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Wallpaper {
-    pub set: bool,
     /// Useful for, for example, killing the wallpaper daemon
     pub pre_hook: Option<String>,
     pub command: String,


### PR DESCRIPTION
## 🤖 New release
* `matugen`: 2.4.0 -> 2.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.5.0](https://github.com/InioX/matugen/compare/v2.4.0...v2.5.0) - 2024-11-13

### Added

- remove `wallpaper.set` option

### Fixed

- add `dump-json` to default featues

### Other

- run cargo fmt
- *(readme)* add discord server link
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).