### PR TITLE
feat: add vibrant color scheme

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -164,7 +164,7 @@ in {
 
     type = lib.mkOption {
       description = "Palette used when generating the colorschemes.";
-      type = lib.types.enum ["scheme-content" "scheme-expressive" "scheme-fidelity" "scheme-fruit-salad" "scheme-monochrome" "scheme-neutral" "scheme-rainbow" "scheme-tonal-spot"];
+      type = lib.types.enum ["scheme-content" "scheme-expressive" "scheme-fidelity" "scheme-fruit-salad" "scheme-monochrome" "scheme-neutral" "scheme-rainbow" "scheme-tonal-spot" "scheme-vibrant"];
       default = osCfg.palette or "scheme-tonal-spot";
       example = "scheme-content";
     };

--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -6,7 +6,7 @@ use material_colors::{
     image::{FilterType, ImageReader},
     scheme::variant::{
         SchemeContent, SchemeExpressive, SchemeFidelity, SchemeFruitSalad, SchemeMonochrome,
-        SchemeNeutral, SchemeRainbow, SchemeTonalSpot,
+        SchemeNeutral, SchemeRainbow, SchemeTonalSpot, SchemeVibrant,
     },
     theme::{ColorGroup, CustomColor, CustomColorGroup},
 };
@@ -170,6 +170,9 @@ pub fn generate_dynamic_scheme(
         }
         SchemeTypes::SchemeTonalSpot => {
             SchemeTonalSpot::new(Hct::new(source_color), is_dark, contrast_level).scheme
+        }
+        SchemeTypes::SchemeVibrant => {
+            SchemeVibrant::new(Hct::new(source_color), is_dark, contrast_level).scheme
         }
     }
 }

--- a/src/gui/init.rs
+++ b/src/gui/init.rs
@@ -116,6 +116,11 @@ impl MyApp {
                     Some(SchemeTypes::SchemeTonalSpot),
                     "SchemeTonalSpot",
                 );
+                ui.selectable_value(
+                    &mut self.app.args.r#type,
+                    Some(SchemeTypes::SchemeVibrant),
+                    "SchemeVibrant",
+                );
             });
     }
 

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -17,6 +17,7 @@ pub enum SchemeTypes {
     SchemeNeutral,
     SchemeRainbow,
     SchemeTonalSpot,
+    SchemeVibrant,
 }
 #[derive(Debug)]
 pub struct Schemes {


### PR DESCRIPTION
Hi,
Thank you for this amazing tool! Makes theming so much easier!
I was also missing the vibrant scheme as: https://github.com/InioX/matugen/issues/144
This PR would add it to the list of the available schemes.