### PR TITLE
feat: add lightness option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - **Custom Keywords/Colors:**
      - Define your own custom keywords or colors you would like to be harmonized inside the config file, that you can then use in templates
 - **Palette Customization:**
-     - Customize the contrast and scheme type for the palette
+     - Customize the contrast, lightness and scheme type for the palette
 - **Restart Apps/Change Wallpaper:**
      - Restart supported apps and set the wallpaper on Windows, MacOS, Linux and NetBSD
 

--- a/benches/template.rs
+++ b/benches/template.rs
@@ -18,7 +18,7 @@ fn parse_template(data: &str) {
 
     let (scheme_dark, scheme_light) = get_schemes(source_color, &None, &None);
     let schemes =
-        get_custom_color_schemes(source_color, scheme_dark, scheme_light, &None, &None, &None);
+        get_custom_color_schemes(source_color, scheme_dark, scheme_light, &None, &None, &None, &None);
     let render_data =
         get_render_data(&schemes, &source_color, &SchemesEnum::Dark, &None, None).unwrap();
 

--- a/module.nix
+++ b/module.nix
@@ -192,8 +192,8 @@ in {
     };
     
     lightness = lib.mkOption {
-      description = "Value from -1 to 1. -1 represents minimum lightness, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum lightness.";
-      type = lib.types.numbers.between (-1) 1;
+      description = "Value from -∞ to 1. -∞ represents minimum lightness, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum lightness. (if the considered lightnesses are between 0 and 1 then this applies an affine transformation to the lightness by keeping the value for 1 at 1 and setting the value for 0 to the lightness argument and then clamping the result)";
+      type = lib.types.addCheck lib.types.number (x: x <= 1.0);
       default = 0;
       example = "0.2";   
     };

--- a/module.nix
+++ b/module.nix
@@ -77,6 +77,7 @@ matugen: {
       --type ${cfg.type} \
       --json ${cfg.jsonFormat} \
       --contrast ${lib.strings.floatToString cfg.contrast} \
+      --lightness ${lib.strings.floatToString cfg.lightness} \
       --quiet \
       > $out/theme.json
   '');
@@ -185,6 +186,13 @@ in {
 
     contrast = lib.mkOption {
       description = "Value from -1 to 1. -1 represents minimum contrast, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum contrast.";
+      type = lib.types.numbers.between (-1) 1;
+      default = 0;
+      example = "0.2";   
+    };
+    
+    lightness = lib.mkOption {
+      description = "Value from -1 to 1. -1 represents minimum lightness, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum lightness.";
       type = lib.types.numbers.between (-1) 1;
       default = 0;
       example = "0.2";   

--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -177,6 +177,16 @@ pub fn generate_dynamic_scheme(
     }
 }
 
+pub fn adjust_color_lightness(
+    color: Argb,
+    lightness_level: &Option<f64>,
+) -> Argb {
+    // If lightness values were plotted on a graph, the effect of this function is to rotate the line corresponding to the identity function about x = 255 and y = 255.
+    let pre_lightness_level = ((color.red as f64) + (color.green as f64) + (color.blue as f64))/ 3.0;
+    let adj = (pre_lightness_level / 255.0 * (1.0 - lightness_level.unwrap_or(0.0)) + lightness_level.unwrap_or(0.0)) / pre_lightness_level* 255.0;
+    Argb::new(color.alpha, (color.red as f64 * adj).clamp(0.0, 255.0) as u8, (color.green as f64 * adj).clamp(0.0, 255.0) as u8, (color.blue as f64 * adj).clamp(0.0, 255.0) as u8)
+}
+
 pub fn make_custom_color(
     color: CustomColor,
     scheme_type: &Option<SchemeTypes>,

--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -181,7 +181,7 @@ pub fn adjust_color_lightness(
     color: Argb,
     lightness_level: &Option<f64>,
 ) -> Argb {
-    // If lightness values were plotted on a graph, the effect of this function is to rotate the line corresponding to the identity function about x = 255 and y = 255.
+    // If lightness values were plotted on a graph, the effect of this function is to rotate the line corresponding to the identity function about x = 255 and y = 255 by setting the value at x = 0 to -lightness_level*255 and then clamping the values to between 0 and 255.
     let pre_lightness_level = ((color.red as f64) + (color.green as f64) + (color.blue as f64))/ 3.0;
     let adj = (pre_lightness_level / 255.0 * (1.0 - lightness_level.unwrap_or(0.0)) + lightness_level.unwrap_or(0.0)) / pre_lightness_level* 255.0;
     Argb::new(color.alpha, (color.red as f64 * adj).clamp(0.0, 255.0) as u8, (color.green as f64 * adj).clamp(0.0, 255.0) as u8, (color.blue as f64 * adj).clamp(0.0, 255.0) as u8)

--- a/src/gui/init.rs
+++ b/src/gui/init.rs
@@ -114,6 +114,11 @@ impl MyApp {
                 &mut self.app.args.contrast.unwrap(),
                 -1.0..=1.0,
             ));
+            ui.label("Lightness");
+            ui.add(egui::Slider::new(
+                &mut self.app.args.lightness.unwrap(),
+                -1.0..=1.0,
+            ));
         });
         ui.label("Scheme type");
         egui::ComboBox::from_label("")

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use matugen::{
     scheme::{get_custom_color_schemes, get_schemes, SchemeTypes},
     template_util::template::get_render_data,
 };
+use owo_colors::OwoColorize;
 use template::{build_engine_syntax, TemplateFile};
 
 use crate::template::Template;
@@ -59,6 +60,7 @@ impl State {
             &config_file.config.custom_colors,
             &args.r#type,
             &args.contrast,
+            &args.lightness,
         );
 
         Self {
@@ -84,6 +86,7 @@ impl State {
             &self.config_file.config.custom_colors,
             &self.args.r#type,
             &self.args.contrast,
+            &self.args.lightness,
         );
     }
 
@@ -189,6 +192,7 @@ fn main() -> Result<(), Report> {
         config: None,
         prefix: None,
         contrast: Some(0.0),
+        lightness: Some(0.0),
         verbose: Some(true),
         quiet: None,
         debug: Some(true),

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use material_colors::scheme::Scheme;
 use std::collections::BTreeSet;
 
-use crate::color::color::{generate_dynamic_scheme, make_custom_color, OwnCustomColor};
+use crate::color::color::{generate_dynamic_scheme, adjust_color_lightness, make_custom_color, OwnCustomColor};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, clap::ValueEnum, Debug, Copy, PartialEq)]
@@ -60,6 +60,7 @@ pub fn get_custom_color_schemes(
     custom_colors: &Option<HashMap<String, OwnCustomColor, std::hash::RandomState>>,
     scheme_type: &Option<SchemeTypes>,
     contrast: &Option<f64>,
+    lightness: &Option<f64>,
 ) -> Schemes {
     macro_rules! from_color {
         ($color: expr, $variant: ident) => {
@@ -103,8 +104,8 @@ pub fn get_custom_color_schemes(
     let custom_colors_light = custom_colors.flat_map(|c| from_color!(c, light));
 
     let schemes: Schemes = Schemes {
-        dark: BTreeSet::from_iter(scheme_dark.into_iter().chain(custom_colors_dark)),
-        light: BTreeSet::from_iter(scheme_light.into_iter().chain(custom_colors_light)),
+        dark: BTreeSet::from_iter(scheme_dark.into_iter().chain(custom_colors_dark).map(|(name, color)| (name,adjust_color_lightness(color, lightness)))),
+        light: BTreeSet::from_iter(scheme_light.into_iter().chain(custom_colors_light).map(|(name, color)| (name,adjust_color_lightness(color, lightness)))),
     };
     schemes
 }

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -34,8 +34,12 @@ pub struct Cli {
     #[arg(long, global = true, allow_negative_numbers = true)]
     pub contrast: Option<f64>,
     
-    /// Value from -1 to 1. -1 represents minimum lightness, 0 represents
+    /// Value from -∞ to 1. -∞ represents minimum lightness, 0 represents
     /// standard (i.e. the design as spec'd), and 1 represents maximum lightness.
+    /// (if the considered lightnesses are between 0 and 1 then this applies an affine
+    /// transformation to the lightness by keeping the value for 1 at 1 and setting the
+    /// value for 0 to the lightness argument and then clamping the result)
+    
     #[arg(long, global = true, allow_negative_numbers = true)]
     pub lightness: Option<f64>,
 

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -33,6 +33,11 @@ pub struct Cli {
     /// standard (i.e. the design as spec'd), and 1 represents maximum contrast.
     #[arg(long, global = true, allow_negative_numbers = true)]
     pub contrast: Option<f64>,
+    
+    /// Value from -1 to 1. -1 represents minimum lightness, 0 represents
+    /// standard (i.e. the design as spec'd), and 1 represents maximum lightness.
+    #[arg(long, global = true, allow_negative_numbers = true)]
+    pub lightness: Option<f64>,
 
     #[arg(short, long, global = true, action=ArgAction::SetTrue)]
     pub verbose: Option<bool>,


### PR DESCRIPTION
Here is a proposed feature,

This PR would add a lightness option to adjust lightness of the outputted color scheme. 

Here's a graph of how the lightness option affects the outputted lightnesses:
https://www.desmos.com/calculator/ayrdrotbqr

This feature would allow [stylix](https://github.com/danth/stylix/) to have a lightness option if it switches to matugen as its color scheme generation engine:
https://github.com/danth/stylix/pull/892

(in the original PR the lightnesses were adjusted post matugen but it's a bit hacky so it would be better to implement it upstream)

Thank you.