### PR TITLE
fix minor typo in nix module build command (fixes #175)

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -90,7 +90,7 @@ matugen: {
       --type ${cfg.type} \
       --json ${cfg.jsonFormat} \
       --contrast ${lib.strings.floatToString cfg.contrast} \
-      --quiet
+      --quiet \
       --include-image-in-json=false \
       > $out/theme.json
   '');


### PR DESCRIPTION
fix a minor typo in the nix module definition. fixes #175.