### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0](https://github.com/InioX/matugen/compare/v3.0.0...v3.1.0) - 2025-11-23
+
+### Added
+
+- add `pre_hook` and `post_hook` to nixos module ([#170](https://github.com/InioX/matugen/pull/170))
+- add fallback color ([#218](https://github.com/InioX/matugen/pull/218))
+- add `loop.index`, `loop.last`, `loop.first` ([#216](https://github.com/InioX/matugen/pull/216))
+- add overwriting syntax per template ([#213](https://github.com/InioX/matugen/pull/213))
+- add `[config.import_json_files]`
+- add `--continue-on-error` ([#209](https://github.com/InioX/matugen/pull/209))
+
+### Fixed
+
+- `mode` first letter being uppercase ([#201](https://github.com/InioX/matugen/pull/201))
+- remove dbg! call in get_source_color
+- caching not working when it doesn't exist ([#184](https://github.com/InioX/matugen/pull/184))
+- cache not overwriting source_color ([#184](https://github.com/InioX/matugen/pull/184))
+- not using the actual mode for colors when caching is enabled ([#212](https://github.com/InioX/matugen/pull/212))
+- if not using the actual else branch when false ([#212](https://github.com/InioX/matugen/pull/212))
+- alpha value being rounded ([#211](https://github.com/InioX/matugen/pull/211))
+
+### Other
+
+- Merge branch 'main' into feat/output-path-array
+- improve errors
+- run `cargo fmt`
+- remove count for exported templates
+- improve how json is imported
+- run `cargo fmt`
+
 ## [2.4.1](https://github.com/InioX/matugen/compare/v2.4.0...v2.4.1) - 2024-11-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ariadne",
  "chumsky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["InioX"]
 description = "A material you color generation tool with templates"
 repository = "https://github.com/InioX/matugen"


### PR DESCRIPTION



## 🤖 New release

* `matugen`: 3.0.0 -> 3.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.1.0](https://github.com/InioX/matugen/compare/v3.0.0...v3.1.0) - 2025-11-23

### Added

- add `pre_hook` and `post_hook` to nixos module ([#170](https://github.com/InioX/matugen/pull/170))
- add fallback color ([#218](https://github.com/InioX/matugen/pull/218))
- add `loop.index`, `loop.last`, `loop.first` ([#216](https://github.com/InioX/matugen/pull/216))
- add overwriting syntax per template ([#213](https://github.com/InioX/matugen/pull/213))
- add `[config.import_json_files]`
- add `--continue-on-error` ([#209](https://github.com/InioX/matugen/pull/209))

### Fixed

- `mode` first letter being uppercase ([#201](https://github.com/InioX/matugen/pull/201))
- remove dbg! call in get_source_color
- caching not working when it doesn't exist ([#184](https://github.com/InioX/matugen/pull/184))
- cache not overwriting source_color ([#184](https://github.com/InioX/matugen/pull/184))
- not using the actual mode for colors when caching is enabled ([#212](https://github.com/InioX/matugen/pull/212))
- if not using the actual else branch when false ([#212](https://github.com/InioX/matugen/pull/212))
- alpha value being rounded ([#211](https://github.com/InioX/matugen/pull/211))

### Other

- Merge branch 'main' into feat/output-path-array
- improve errors
- run `cargo fmt`
- remove count for exported templates
- improve how json is imported
- run `cargo fmt`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).