### PR TITLE
feat: add hook index

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -34,6 +34,7 @@ pub struct Template {
     pub expr_postfix: Option<String>,
     pub block_prefix: Option<String>,
     pub block_postfix: Option<String>,
+    pub index: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -121,7 +122,12 @@ impl TemplateFile<'_> {
             };
         }
 
-        for (name, template) in self.state.config_file.templates.iter() {
+        // Iterate over sorted templates when running command hooks
+        let mut templates: Vec<(&String, &Template)> = self.state.config_file.templates.iter().collect();
+        // Templates with an unspecified `index` default to 0
+        templates.sort_by_key(|(_, Template { index, .. })| index.unwrap_or(0));
+
+        for (name, template) in templates {
             if let Some(hook) = &template.pre_hook {
                 info!("Running pre_hook for the <b><cyan>{}</> template.", &name);
                 format_hook(


### PR DESCRIPTION
_Note: I'm marking this PR as a draft to review potential wiki changes before merging_

simply adds an `index: Option<i32>` field to the `Template` struct, which `matugen` can use to sort its list of templates before running the command hook phase.

The motivation behind this feature is that some users may want the freedom in choosing the order that each template is processed. For a somewhat situational example, observe the following `matugen` config file:

```toml
[templates.waybar]
input_path = './templates/waybar/template.css'
output_path = '~/.config/waybar/style.css'
post_hook = 'pkill -SIGUSR2 waybar || true'
```

Additionally, suppose the user has a script like the one below, which is executed `on-click` from a `waybar` module:

```bash
set -e

pkill hellpaper || WALL=$(hellpaper --recursive ~/Pictures/backgrounds/) # GUI to select wallpaper
if [ -z "$WALL" ]; then
  exit 1
fi
matugen image \"$WALL\"
```

Due to the randomized order of command hook execution, `pkill -SIGUSR2 waybar` may run before some (or even all) of the other defined templates, killing `waybar` (and in-turn, `matugen`), leading to seemingly random behavior. While this can likely be fixed by manually orphaning the script or the `matugen` process, it demonstrates a use-case. 

For flexibility, I have defined the `index` field as a signed integer that defaults to a value of `0` if unspecified in the config file. Along with having no impact to current configurations, this has the nice benefit that a user need only add `index = n` to force a particular template hook to run _after_ everything else, and `index = -n` for _before_ everything else. Using the above `waybar` example, one would have:

```toml
[templates.waybar]
input_path = './templates/waybar/template.css'
output_path = '~/.config/waybar/style.css'
post_hook = 'pkill -SIGUSR2 waybar || true'
index = 1
```