### PR TITLE
fix: streamline `hsl_to_argb` function

### DIFF
--- a/src/color/format.rs
+++ b/src/color/format.rs
@@ -12,12 +12,7 @@ pub fn argb_from_rgb(color: &Rgb) -> Argb {
 
 pub fn argb_from_hsl(color: &Hsl) -> Argb {
     let color: Rgb = color.into();
-    Argb {
-        red: color.red() as u8,
-        green: color.blue() as u8,
-        blue: color.blue() as u8,
-        alpha: color.alpha() as u8,
-    }
+    argb_from_rgb(&color)
 }
 
 pub fn rgb_from_argb(color: Argb) -> Rgb {


### PR DESCRIPTION
While working on the color based base16 calculation, I noticed that my colors where looking odd... Turns out the alpha value of the `hsl_to_argb` function was scuffed and that's why I was getting weird results.

Anyways. I propose to just forward the function to call `rgb_to_argb` instead of making the same calculations in the hsl function.