### PR TITLE
feat: add hex alpha formats

### DIFF
--- a/src/color/format.rs
+++ b/src/color/format.rs
@@ -40,6 +40,38 @@ pub fn format_hex_stripped(color: &Rgb) -> String {
     color.to_hex_string()[1..].to_string()
 }
 
+pub fn format_hex_alpha(color: &Rgb) -> String {
+    let alpha = alpha_u8(color.alpha());
+    format!(
+        "#{:02X}{:02X}{:02X}{:02X}",
+        color.red() as u8,
+        color.green() as u8,
+        color.blue() as u8,
+        alpha
+    )
+}
+
+pub fn format_hex_alpha_stripped(color: &Rgb) -> String {
+    let alpha = alpha_u8(color.alpha());
+    format!(
+        "{:02X}{:02X}{:02X}{:02X}",
+        color.red() as u8,
+        color.green() as u8,
+        color.blue() as u8,
+        alpha
+    )
+}
+
+// alpha can be 0..1 (CSS parsing / set_alpha) or 0..255 (ARGB conversions).
+// Normalize to 0..255 so hex output is consistent.
+fn alpha_u8(alpha: f64) -> u8 {
+    if alpha <= 1.0 {
+        (alpha.clamp(0.0, 1.0) * 255.0).round() as u8
+    } else {
+        alpha.clamp(0.0, 255.0).round() as u8
+    }
+}
+
 pub fn format_rgb(color: &Rgb) -> String {
     format!(
         "rgb({:?}, {:?}, {:?})",

--- a/src/parser/engine/replace.rs
+++ b/src/parser/engine/replace.rs
@@ -9,7 +9,8 @@ use crate::parser::{
 };
 
 use crate::color::format::{
-    format_hex, format_hex_stripped, format_hsl, format_hsla, format_rgb, format_rgba,
+    format_hex, format_hex_alpha, format_hex_alpha_stripped, format_hex_stripped, format_hsl,
+    format_hsla, format_rgb, format_rgba,
 };
 
 use super::Engine;
@@ -17,6 +18,8 @@ use super::Engine;
 pub const FORMATS: &[&str] = &[
     "hex",
     "hex_stripped",
+    "hex_alpha",
+    "hex_alpha_stripped",
     "rgb",
     "rgba",
     "hsl",
@@ -49,6 +52,8 @@ pub fn format_color(base_color: Rgb, format: &str) -> Option<Value> {
         f if FORMATS.contains(&f) => match f {
             "hex" => Some(format_hex(&base_color).into()),
             "hex_stripped" => Some(format_hex_stripped(&base_color).into()),
+            "hex_alpha" => Some(format_hex_alpha(&base_color).into()),
+            "hex_alpha_stripped" => Some(format_hex_alpha_stripped(&base_color).into()),
             "rgb" => Some(format_rgb(&base_color).into()),
             "rgba" => Some(format_rgba(&base_color, false).into()),
             "hsl" => Some(format_hsl(&hsl_color).into()),
@@ -73,6 +78,8 @@ pub fn format_color_hsl(hsl_color: Hsl, format: &str) -> Option<Value> {
         f if FORMATS.contains(&f) => match f {
             "hex" => Some(format_hex(&base_color).into()),
             "hex_stripped" => Some(format_hex_stripped(&base_color).into()),
+            "hex_alpha" => Some(format_hex_alpha(&base_color).into()),
+            "hex_alpha_stripped" => Some(format_hex_alpha_stripped(&base_color).into()),
             "rgb" => Some(format_rgb(&base_color).into()),
             "rgba" => Some(format_rgba(&base_color, false).into()),
             "hsl" => Some(format_hsl(&hsl_color).into()),
@@ -99,6 +106,14 @@ pub fn format_color_all(base_color: Rgb) -> IndexMap<String, Value> {
     map.insert(
         "hex_stripped".to_string(),
         Value::Ident(format_hex_stripped(&base_color)),
+    );
+    map.insert(
+        "hex_alpha".to_string(),
+        Value::Ident(format_hex_alpha(&base_color)),
+    );
+    map.insert(
+        "hex_alpha_stripped".to_string(),
+        Value::Ident(format_hex_alpha_stripped(&base_color)),
     );
     map.insert("rgb".to_string(), Value::Ident(format_rgb(&base_color)));
     map.insert(

--- a/src/template_util/template.rs
+++ b/src/template_util/template.rs
@@ -6,8 +6,8 @@ use material_colors::color::Argb;
 
 use crate::{
     color::format::{
-        format_hex, format_hex_stripped, format_hsl, format_hsla, format_rgb, format_rgba,
-        rgb_from_argb,
+        format_hex, format_hex_alpha, format_hex_alpha_stripped, format_hex_stripped, format_hsl,
+        format_hsla, format_rgb, format_rgba, rgb_from_argb,
     },
     scheme::{Schemes, SchemesEnum},
 };
@@ -16,6 +16,8 @@ use crate::{
 pub struct Color {
     hex: String,
     hex_stripped: String,
+    hex_alpha: String,
+    hex_alpha_stripped: String,
     rgb: String,
     rgba: String,
     hsl: String,
@@ -100,6 +102,8 @@ fn generate_color_strings(color: Argb) -> Color {
     Color {
         hex: format_hex(&base_color),
         hex_stripped: format_hex_stripped(&base_color),
+        hex_alpha: format_hex_alpha(&base_color),
+        hex_alpha_stripped: format_hex_alpha_stripped(&base_color),
         rgb: format_rgb(&base_color),
         rgba: format_rgba(&base_color, true),
         hsl: format_hsl(&hsl_color),


### PR DESCRIPTION
This PR implements new output formats for the template engine: `hex_alpha` and `hex_alpha_stripped`. These new formats are designed to output `#RRGGBBAA` and `RRGGBBAA` format, respectively. Both formats support alpha channel manipulation via the `set_alpha` filter.

Usage in template:
```
{{ colors.surface.default.hex_alpha | set_alpha: 0.8 }}
```
and for `hex_alpha_stripped`:
```
{{ colors.surface.default.hex_alpha_stripped | set_alpha: 0.8 }}
```

`hex_alpha` and `hex_alpha_stripped` default to fully opaque (FF) unless modified by `set_alpha`.

Closes #248 

Thanks @InioX again for letting me be a part of Matugen!