### PR TITLE
feat: add algorithm for a base16 theme from one source color

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,13 +89,14 @@ pub fn generate_schemes_and_theme(
     };
 
     let base_16 = match &args.source {
-        Source::Image { path } => {
-            let schemes =
-                generate_base16_schemes(path, args.base16_backend.clone().unwrap_or(Backend::Wal))
-                    .wrap_err("Failed to generate base16 color schemes.")?;
-            Some(schemes)
-        }
-        _ => None,
+        Source::Json { path: _ } => None,
+        _ => Some(
+            generate_base16_schemes(
+                &args.source,
+                args.base16_backend.clone().unwrap_or(Backend::Wal),
+            )
+            .wrap_err("Failed to generate base16 color schemes.")?,
+        ),
     };
 
     Ok((schemes, source_color, theme, base_16))


### PR DESCRIPTION
Tried to map the standard semantics (https://github.com/chriskempson/base16/blob/main/styling.md) of base16 as closely as possible, while giving each accent a distinct look. Currently very hardcoded, but it's at least something. Syntax parts that are semantically close together also share similarities in color shift, while keywords and escape sequences are more close to the tertiary color of md3 algorithm.