### PR TITLE
refactor: shorten flat match for `DynamicScheme` generation

### DIFF
--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -3,13 +3,9 @@ use material_colors::{
     blend::harmonize,
     color::Argb,
     dynamic_color::{DynamicScheme, MaterialDynamicColors},
-    hct::{Cam16, Hct},
+    hct::Cam16,
     image::{FilterType, ImageReader},
     quantize::{Quantizer, QuantizerCelebi},
-    scheme::variant::{
-        SchemeContent, SchemeExpressive, SchemeFidelity, SchemeFruitSalad, SchemeMonochrome,
-        SchemeNeutral, SchemeRainbow, SchemeTonalSpot, SchemeVibrant,
-    },
     score::Score,
     theme::{ColorGroup, CustomColor, CustomColorGroup},
 };
@@ -274,34 +270,11 @@ pub fn generate_dynamic_scheme(
     is_dark: bool,
     contrast_level: Option<f64>,
 ) -> DynamicScheme {
-    match scheme_type.unwrap_or(SchemeTypes::SchemeContent) {
-        SchemeTypes::SchemeContent => {
-            SchemeContent::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeExpressive => {
-            SchemeExpressive::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeFidelity => {
-            SchemeFidelity::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeFruitSalad => {
-            SchemeFruitSalad::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeMonochrome => {
-            SchemeMonochrome::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeNeutral => {
-            SchemeNeutral::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeRainbow => {
-            SchemeRainbow::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeTonalSpot => {
-            SchemeTonalSpot::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
-        SchemeTypes::SchemeVibrant => {
-            SchemeVibrant::new(Hct::new(source_color), is_dark, contrast_level).scheme
-        }
+    let scheme_type: SchemeTypes = scheme_type.unwrap_or(SchemeTypes::SchemeContent);
+    if let Some(var) = scheme_type.as_material_colors_variant() {
+        DynamicScheme::by_variant(source_color, &var, is_dark, contrast_level)
+    } else {
+        unreachable!()
     }
 }
 

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use material_colors::scheme::Scheme;
+use material_colors::{dynamic_color::Variant as MaterialColorsVariant, scheme::Scheme};
 use serde::Serialize;
 
 use crate::color::color::{
@@ -22,6 +22,24 @@ pub enum SchemeTypes {
     SchemeRainbow,
     SchemeTonalSpot,
     SchemeVibrant,
+}
+
+impl SchemeTypes {
+    #[allow(unreachable_patterns)]
+    pub fn as_material_colors_variant(&self) -> Option<MaterialColorsVariant> {
+        match self {
+            SchemeTypes::SchemeContent => Some(MaterialColorsVariant::Content),
+            SchemeTypes::SchemeExpressive => Some(MaterialColorsVariant::Expressive),
+            SchemeTypes::SchemeFidelity => Some(MaterialColorsVariant::Fidelity),
+            SchemeTypes::SchemeFruitSalad => Some(MaterialColorsVariant::FruitSalad),
+            SchemeTypes::SchemeMonochrome => Some(MaterialColorsVariant::Monochrome),
+            SchemeTypes::SchemeNeutral => Some(MaterialColorsVariant::Neutral),
+            SchemeTypes::SchemeRainbow => Some(MaterialColorsVariant::Rainbow),
+            SchemeTypes::SchemeTonalSpot => Some(MaterialColorsVariant::TonalSpot),
+            SchemeTypes::SchemeVibrant => Some(MaterialColorsVariant::Vibrant),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
In terms of simplifying and streamlining the function calls I propose to let the `SchemeTypes` enum provide maps to different backends (if we ever come to making new scheme types for example). This way the `generate_dynamic_scheme` function just has to call `DynamicScheme::by_variant` for the `material_colors` internal variants, skipping the need to include all different variants thus simplifying the include structure.