### PR TITLE
fix: turn source_color_index comment into a doc comment

### DIFF
--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -121,10 +121,11 @@ pub struct Cli {
     #[arg(long, global = true, allow_negative_numbers = true)]
     pub lightness_light: Option<f64>,
 
-    // Will automatically pick a source color based on the index provided (0 - 4)
-    // 0 = most dominant, 1 = 2nd most dominant, etc.
-    // Setting this to any value will not show the selection prompt.
-    // In earlier versions the default was 0.
+    /// Will automatically pick a source color based on the index provided (0 - 4)
+    /// 0 = most dominant, 1 = 2nd most dominant, etc.
+    ///
+    /// Setting this to any value will not show the selection prompt.
+    /// In earlier versions the default was 0.
     #[arg(long, global = true, value_parser = clap::builder::RangedI64ValueParser::<i64>::new().range(0..4))]
     pub source_color_index: Option<i64>,
 }


### PR DESCRIPTION
The comment for `--source_color_index` was set as a regular comment, making its use vague, when it was probably intended as a doc comment which lets it be visible in the clap `--help`.