### PR TITLE
fix {{image}} path creation for Windows.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,10 @@ impl State {
 
     pub fn get_render_data(&self) -> Result<serde_json::Value, Report> {
         let image = match &self.args.source {
-            Source::Image { path } => Some(path.replace('\\', "\\\\")),
+            Source::Image { path } => {
+                let normalized = normalize_backslashes(path);
+                Some(normalized.replace('\\', r"\\"))
+            }
             #[cfg(feature = "web-image")]
             Source::WebImage { .. } => None,
             Source::Color { .. } => None,
@@ -631,6 +634,24 @@ impl State {
 
         Ok(())
     }
+}
+
+fn normalize_backslashes(path: &str) -> String {
+    let mut result = String::with_capacity(path.len());
+    let mut prev_was_backslash = false;
+
+    for c in path.chars() {
+        if c == '\\' {
+            if !prev_was_backslash {
+                result.push(c);
+                prev_was_backslash = true;
+            }
+        } else {
+            result.push(c);
+            prev_was_backslash = false;
+        }
+    }
+    result
 }
 
 #[allow(unreachable_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ impl State {
 
     pub fn get_render_data(&self) -> Result<serde_json::Value, Report> {
         let image = match &self.args.source {
-            Source::Image { path } => Some(path),
+            Source::Image { path } => Some(path.replace('\\', "\\\\")),
             #[cfg(feature = "web-image")]
             Source::WebImage { .. } => None,
             Source::Color { .. } => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,10 +211,7 @@ impl State {
 
     pub fn get_render_data(&self) -> Result<serde_json::Value, Report> {
         let image = match &self.args.source {
-            Source::Image { path } => {
-                let normalized = normalize_backslashes(path);
-                Some(normalized.replace('\\', r"\\"))
-            }
+            Source::Image { path } => Some(normalize_path_to_forward_slash(path)),
             #[cfg(feature = "web-image")]
             Source::WebImage { .. } => None,
             Source::Color { .. } => None,
@@ -636,7 +633,7 @@ impl State {
     }
 }
 
-fn normalize_backslashes(path: &str) -> String {
+fn normalize_path_to_forward_slash(path: &str) -> String {
     let mut result = String::with_capacity(path.len());
     let mut prev_was_backslash = false;
 
@@ -651,7 +648,7 @@ fn normalize_backslashes(path: &str) -> String {
             prev_was_backslash = false;
         }
     }
-    result
+    result.replace('\\', "/")
 }
 
 #[allow(unreachable_code)]


### PR DESCRIPTION
Avoid single `\` escape issues for image path on Windows.
The changes wont effect any Unix pathing.
fixes - https://github.com/InioX/matugen/issues/271

https://github.com/user-attachments/assets/a1ec66fd-c33f-4035-be79-74fba0af7210



