### PR TITLE
chore: release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0](https://github.com/InioX/matugen/compare/v4.1.0...v4.2.0) - 2026-05-15
+
+### Added
+
+- add cache for per template scheme types ([#292](https://github.com/InioX/matugen/pull/292))
+
+### Fixed
+
+- change ordering for base16 accents from image (#286, #283)
+
+### Other
+
+- Merge pull request #290 from haikalllp/fix/tildeUsageOnHooks
+- remove indices from show_source_colors output
+- make listing source colors an arg for image instead of a different command
+- added new image-colors command to list possible source colors from image
+- use `swap_remove` to remove warning
+- cargo fmt
+- cli_overides cont.
+- SchemeType-specific cache ([#295](https://github.com/InioX/matugen/pull/295))
+- move cli overrides to a dedicated function
+
+### Removed
+
+- removed unnecessary import
+
 ## [4.1.0](https://github.com/InioX/matugen/compare/v4.0.0...v4.1.0) - 2026-03-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0](https://github.com/InioX/matugen/compare/v4.1.0...v4.2.0) - 2026-06-06
+
+### Added
+
+- add `source_color_index` to config (closes #289)
+- add cache for per template scheme types ([#292](https://github.com/InioX/matugen/pull/292))
+
+### Fixed
+
+- change ordering for base16 accents from image (#286, #283)
+
+### Other
+
+- Merge pull request #290 from haikalllp/fix/tildeUsageOnHooks
+- remove indices from show_source_colors output
+- make listing source colors an arg for image instead of a different command
+- added new image-colors command to list possible source colors from image
+- use `swap_remove` to remove warning
+- cargo fmt
+- cli_overides cont.
+- SchemeType-specific cache ([#295](https://github.com/InioX/matugen/pull/295))
+- move cli overrides to a dedicated function
+
+### Removed
+
+- removed unnecessary import
+
 ## [4.1.0](https://github.com/InioX/matugen/compare/v4.0.0...v4.1.0) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "matugen"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "ariadne",
  "chumsky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matugen"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["InioX"]
 description = "A material you and base16 color generation tool with templates"
 repository = "https://github.com/InioX/matugen"


### PR DESCRIPTION



## 🤖 New release

* `matugen`: 4.1.0 -> 4.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.0](https://github.com/InioX/matugen/compare/v4.1.0...v4.2.0) - 2026-06-06

### Added

- add `source_color_index` to config (closes #289)
- add cache for per template scheme types ([#292](https://github.com/InioX/matugen/pull/292))

### Fixed

- change ordering for base16 accents from image (#286, #283)

### Other

- Merge pull request #290 from haikalllp/fix/tildeUsageOnHooks
- remove indices from show_source_colors output
- make listing source colors an arg for image instead of a different command
- added new image-colors command to list possible source colors from image
- use `swap_remove` to remove warning
- cargo fmt
- cli_overides cont.
- SchemeType-specific cache ([#295](https://github.com/InioX/matugen/pull/295))
- move cli overrides to a dedicated function

### Removed

- removed unnecessary import
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).