### PR TITLE
fix: expand tilde in hook commands for cross-platform support

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -24,6 +24,7 @@ use std::{
     path::PathBuf,
 };
 
+use directories::BaseDirs;
 use resolve_path::PathResolveExt;
 
 use crate::{SchemesEnum, State};
@@ -348,6 +349,7 @@ pub fn format_hook(
         }
     };
 
+    let res = expand_tilde(&res);
     let mut command = shell(&res);
 
     // FIXME: figure out why this doesnt work even though its in the docs
@@ -378,6 +380,19 @@ pub fn format_hook(
     }
 
     Ok(())
+}
+
+fn expand_tilde(input: &str) -> String {
+    let Some(base_dirs) = BaseDirs::new() else {
+        return input.to_string();
+    };
+    let home = base_dirs.home_dir().to_string_lossy().to_string();
+    input
+        .replace("~/", &format!("{}{}", home, std::path::MAIN_SEPARATOR))
+        .replace(
+            &format!("~{}", std::path::MAIN_SEPARATOR),
+            &format!("{}{}", home, std::path::MAIN_SEPARATOR),
+        )
 }
 
 #[allow(clippy::manual_strip)]


### PR DESCRIPTION
Adds tilde (`~`) expansion in `format_hook` so using `~/` or `~\` will go to the user's home in any os.

now can do this on any platform:
```bash
prehook = ~/.local/bin/scripts/pre-wallpaper.sh
posthook = python ~/.local/bin/scripts/myscripts.py
```