### PR TITLE
refactor: Simplify scheme type and config overrides

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,8 +7,8 @@ use std::{
 
 use crate::{
     color::color::Source,
-    scheme::Schemes,
-    util::config::{get_proj_path, ProjectDirsTypes},
+    scheme::{SchemeTypes, Schemes},
+    util::config::{ProjectDirsTypes, get_proj_path},
 };
 use color_eyre::Report;
 use image::ImageReader;
@@ -134,12 +134,13 @@ pub fn convert_argb_scheme(scheme: &IndexMap<String, Argb>) -> IndexMap<String, 
 
 pub struct ImageCache {
     pub hash: Option<String>,
+    pub stype: SchemeTypes,
     source: Option<PathBuf>,
     cache_folder: PathBuf,
 }
 
 impl ImageCache {
-    pub fn new(source: &Source) -> Self {
+    pub fn new(source: &Source, stype: SchemeTypes) -> Self {
         let pathbuf = match source {
             Source::Image { path } => Some(PathBuf::from(path)),
             _ => None,
@@ -151,6 +152,7 @@ impl ImageCache {
 
         Self {
             hash: get_cache(source),
+            stype,
             source: pathbuf,
             cache_folder,
         }
@@ -209,20 +211,18 @@ impl ImageCache {
 
     fn get_name(&self) -> PathBuf {
         let name = format!(
-            "{}.{}.json",
+            "{}.{}.{:?}.json",
             self.source
                 .as_ref()
                 .unwrap()
                 .file_name()
                 .unwrap()
                 .to_string_lossy(),
-            self.hash.as_ref().unwrap()
+            &self.hash.as_ref().unwrap(),
+            &self.stype
         );
 
-        let mut file = PathBuf::new();
-        file.push(name);
-
-        file
+        PathBuf::from(name)
     }
 
     pub fn exists(&self) -> bool {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     color::color::Source,
     scheme::{SchemeTypes, Schemes},
-    util::config::{ProjectDirsTypes, get_proj_path},
+    util::config::{get_proj_path, ProjectDirsTypes},
 };
 use color_eyre::Report;
 use image::ImageReader;

--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -344,12 +344,11 @@ pub fn get_source_color_from_color(color: &ColorFormat) -> Result<Argb, Report> 
 }
 
 pub fn generate_dynamic_scheme(
-    scheme_type: &Option<SchemeTypes>,
+    scheme_type: SchemeTypes,
     source_color: Argb,
     is_dark: bool,
     contrast_level: Option<f64>,
 ) -> DynamicScheme {
-    let scheme_type: SchemeTypes = scheme_type.unwrap_or(SchemeTypes::SchemeContent);
     if let Some(var) = scheme_type.as_material_colors_variant() {
         DynamicScheme::by_variant(source_color, &var, is_dark, contrast_level)
     } else {
@@ -359,7 +358,7 @@ pub fn generate_dynamic_scheme(
 
 pub fn make_custom_color(
     color: CustomColor,
-    scheme_type: &Option<SchemeTypes>,
+    scheme_type: SchemeTypes,
     source_color: Argb,
     contrast_level: Option<f64>,
 ) -> CustomColorGroup {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -79,7 +79,7 @@ pub fn merge_json_source(
 pub fn generate_schemes_and_theme(
     args: &Cli,
     config_file: &ConfigFile,
-    scheme_type: &Option<SchemeTypes>,
+    scheme_type: SchemeTypes,
 ) -> Result<
     (
         Option<Schemes>,
@@ -136,7 +136,7 @@ pub fn generate_schemes_and_theme(
                 scheme_dark,
                 scheme_light,
                 &config_file.config.custom_colors,
-                &args.r#type,
+                args.r#type,
                 &contrast,
                 &args.lightness_dark,
                 &args.lightness_light,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,19 +89,7 @@ pub fn generate_schemes_and_theme(
     ),
     Report,
 > {
-    let fallback = if args.fallback_color.is_some() {
-        &args.fallback_color
-    } else {
-        &config_file.config.fallback_color
-    };
-
-    let prefer = if args.prefer.is_some() {
-        &args.prefer
-    } else {
-        &config_file.config.prefer
-    };
-
-    let parsed_fallback_color: Option<Argb> = match fallback {
+    let parsed_fallback_color: Option<Argb> = match &config_file.config.fallback_color {
         Some(s) => {
             let c = parse_css_color(&s)
                 .wrap_err("Failed to parse the fallback_color string as a css color")?;
@@ -117,7 +105,7 @@ pub fn generate_schemes_and_theme(
                 &args.source,
                 &args.resize_filter,
                 parsed_fallback_color,
-                prefer,
+                &config_file.config.prefer,
                 &args.source_color_index,
             ))
             .wrap_err("Failed to get source color.")?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,10 @@ impl State {
         #[cfg(feature = "jxl-image")]
         jxl_oxide::integration::register_image_decoding_hook();
 
-        let (config_file, config_path) =
+        let (mut config_file, config_path) =
             ConfigFile::read(&args).wrap_err("Failed to read config file.")?;
+
+        config_file.parse_cli_overrides(&args);
 
         let image_cache = ImageCache::new(&args.source);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ impl State {
 
         config_file.parse_cli_overrides(&args);
 
-        let image_cache = ImageCache::new(&args.source);
+        let image_cache = ImageCache::new(&args.source, args.r#type);
 
         let mut loaded_cache = false;
 
@@ -101,14 +101,14 @@ impl State {
                             "<d>The cache in <yellow><b>{}</><d> doesn't exist.</>",
                             image_cache.get_path().display()
                         );
-                        generate_schemes_and_theme(&args, &config_file, &args.r#type)?
+                        generate_schemes_and_theme(&args, &config_file, args.r#type)?
                     } else {
                         return Err(e.wrap_err("Couldn't load the cache file").suggestion("You may need to regenerate your cache if coming from v3.1.0 and lower."));
                     }
                 }
             }
         } else {
-            generate_schemes_and_theme(&args, &config_file, &args.r#type)?
+            generate_schemes_and_theme(&args, &config_file, args.r#type)?
         };
 
         apply_opacity_to_schemes(&mut base16, args.opacity);
@@ -666,7 +666,7 @@ fn main() -> Result<(), Report> {
         source: crate::Source::Color(crate::color::color::ColorFormat::Hex {
             string: String::from("#ffffff"),
         }),
-        r#type: Some(SchemeTypes::SchemeContent),
+        r#type: SchemeTypes::SchemeContent,
         config: None,
         prefix: None,
         contrast: Some(0.0),

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -11,7 +11,9 @@ use crate::color::color::{
 };
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone, clap::ValueEnum, Debug, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Default)]
+#[derive(
+    Clone, clap::ValueEnum, Debug, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Default,
+)]
 pub enum SchemeTypes {
     #[default]
     SchemeContent,
@@ -188,7 +190,13 @@ mod tests {
     fn schemes_eq() {
         let source_color = material_colors::color::Argb::new(255, 255, 0, 0);
         assert_eq!(
-            Scheme::from(generate_dynamic_scheme(SchemeTypes::default(), source_color, true, None,)).primary,
+            Scheme::from(generate_dynamic_scheme(
+                SchemeTypes::default(),
+                source_color,
+                true,
+                None,
+            ))
+            .primary,
             Argb {
                 alpha: 255,
                 red: 255,

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -11,8 +11,9 @@ use crate::color::color::{
 };
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone, clap::ValueEnum, Debug, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, clap::ValueEnum, Debug, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Default)]
 pub enum SchemeTypes {
+    #[default]
     SchemeContent,
     SchemeExpressive,
     SchemeFidelity,
@@ -95,7 +96,7 @@ pub fn get_custom_color_schemes(
     scheme_dark: Scheme,
     scheme_light: Scheme,
     custom_colors: &Option<HashMap<String, OwnCustomColor, std::hash::RandomState>>,
-    scheme_type: &Option<SchemeTypes>,
+    scheme_type: SchemeTypes,
     contrast: &Option<f64>,
     lightness_dark: &Option<f64>,
     lightness_light: &Option<f64>,
@@ -160,7 +161,7 @@ pub fn get_custom_color_schemes(
 
 pub fn get_schemes(
     source_color: material_colors::color::Argb,
-    scheme_type: &Option<SchemeTypes>,
+    scheme_type: SchemeTypes,
     contrast: &Option<f64>,
 ) -> (Scheme, Scheme) {
     let scheme_dark = Scheme::from(generate_dynamic_scheme(
@@ -187,7 +188,7 @@ mod tests {
     fn schemes_eq() {
         let source_color = material_colors::color::Argb::new(255, 255, 0, 0);
         assert_eq!(
-            Scheme::from(generate_dynamic_scheme(&None, source_color, true, None,)).primary,
+            Scheme::from(generate_dynamic_scheme(SchemeTypes::default(), source_color, true, None,)).primary,
             Argb {
                 alpha: 255,
                 red: 255,

--- a/src/template.rs
+++ b/src/template.rs
@@ -163,7 +163,7 @@ impl TemplateFile<'_> {
                     let (mut schemes, _, theme, mut base16) = generate_schemes_and_theme(
                         &self.state.args,
                         &self.state.config_file,
-                        &Some(scheme_type),
+                        scheme_type,
                     )?;
 
                     apply_opacity_to_schemes(&mut base16, self.state.args.opacity);

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -20,7 +20,7 @@ pub struct Cli {
         global = true,
         default_value = "scheme-tonal-spot"
     )]
-    pub r#type: Option<crate::scheme::SchemeTypes>,
+    pub r#type: crate::scheme::SchemeTypes,
 
     /// Sets a custom config file
     #[arg(short, long, value_name = "FILE", global = true)]

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -107,4 +107,13 @@ impl ConfigFile {
     fn read_from_fallback_path() -> Result<ConfigFile, Report> {
         Ok(toml::from_str(DEFAULT_CONFIG)?)
     }
+
+    pub fn parse_cli_overrides(&mut self, cli: &Cli) {
+        if cli.fallback_color.is_some() {
+            self.config.fallback_color = cli.fallback_color.clone();
+        }
+        if cli.prefer.is_some() {
+            self.config.prefer = cli.prefer.clone();
+        }
+    }
 }


### PR DESCRIPTION
adds an `stype` param for ImageCache. allows for a cache specific to each scheme variant so specifying a type doesn't get ignored if you cached a different type in the past.

I needed to move the cli overrides to do this, and I think it makes sense for an override like this to be right after parsing.

It's cheaper to pass a 0x1 enum by value than by reference, and the unneceassary Option<>s leave a bit of noise so I also modified uses of `scheme_type` parameter to be passed directly as `SchemeTypes` instead of `&Option<SchemeTypes>`, etc.
