### PR TITLE
Added list candidates flag

### DIFF
--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -146,6 +146,7 @@ pub fn get_source_color(
     fallback_color: Option<Argb>,
     prefer: &Option<SelectionPreference>,
     source_color_index: &Option<i64>,
+    list_candidates: bool,
 ) -> Result<Argb, Report> {
     use crate::color::color;
 
@@ -163,6 +164,7 @@ pub fn get_source_color(
                 fallback_color,
                 &prefer,
                 source_color_index,
+                list_candidates,
             )
             .wrap_err(format!("Could not get source color from image: {}", path))?
         }
@@ -187,6 +189,7 @@ pub fn get_source_color_from_image(
     fallback_color: Option<Argb>,
     prefer: &Option<SelectionPreference>,
     source_color_index: &Option<i64>,
+    list_candidates: bool,
 ) -> Result<Argb, Report> {
     let mut original = ImageReader::open(path)?;
     let image = original.resize(112, 112, filter_type);
@@ -203,6 +206,12 @@ pub fn get_source_color_from_image(
         .retain(|&argb, _| Cam16::from(argb).chroma >= 5.0);
 
     let ranked = Score::score(&result.color_to_count, None, fallback_color, None);
+
+    if list_candidates {
+        let json: Vec<String> = ranked.iter().map(|c| c.to_hex_with_pound()).collect();
+        println!("{}", serde_json::to_string(&json).unwrap());
+        std::process::exit(0);
+    }
 
     let ranked_formatted: Vec<String> = ranked
         .clone()

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -107,6 +107,7 @@ pub fn generate_schemes_and_theme(
                 parsed_fallback_color,
                 &config_file.config.prefer,
                 &args.source_color_index,
+                args.list_candidates.unwrap_or(false),
             ))
             .wrap_err("Failed to get source color.")?,
         ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,6 +692,7 @@ fn main() -> Result<(), Report> {
         lightness_light: Some(0.0),
         source_color_index: None,
         opacity: Some(1.0),
+        list_candidates: Some(false),
     };
 
     let args = Cli::parse();

--- a/src/util/arguments.rs
+++ b/src/util/arguments.rs
@@ -138,6 +138,10 @@ pub struct Cli {
     // This will set the opacity for all colors inside templates.
     #[arg(long, global = true , value_parser = |s: &str| validate_float_range(s, 0.0..=1.0))]
     pub opacity: Option<f64>,
+
+    /// List source color candidates as JSON and exit.
+    #[arg(long, global = true, action=ArgAction::SetTrue, default_value = "false")]
+    pub list_candidates: Option<bool>,
 }
 
 fn validate_float_range<R>(s: &str, range: R) -> Result<f64, String>


### PR DESCRIPTION
I've implemented a `--list-candidates` flag that returns the 4 source color choices in the manual select prompt, since i needed those programmatically. 
This would also address Issue https://github.com/InioX/matugen/issues/297 !!!

code may not be the best.