### PR TITLE
fix: make templates input_path a dependency of the flake module

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -79,12 +79,12 @@ matugen: {
     then "image ${cfg.wallpaper}"
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
-  themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
-  } ''
+  themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {} ''
     mkdir -p $out
     cd $out
     export HOME=$(pwd)
+
+    : ${lib.concatStringsSep " " (map (v: "${v.input_path}") (builtins.attrValues cfg.templates))} # Force Nix to track our templates
 
     ${cfg.package}/bin/matugen \
       ${command} \

--- a/module.nix
+++ b/module.nix
@@ -37,10 +37,9 @@ matugen: {
   # don't use ~, use $HOME
   sanitizedTemplates =
     builtins.mapAttrs (_: v: {
+      mode = capitalize cfg.variant;
       input_path = v.input_path;
-      output_path = let
-          paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
-        in if builtins.length paths == 1 then builtins.head paths else paths;
+      output_path = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
     })
     cfg.templates;
 
@@ -83,8 +82,6 @@ matugen: {
     mkdir -p $out
     cd $out
     export HOME=$(pwd)
-
-    : ${lib.concatStringsSep " " (map (v: "${v.input_path}") (builtins.attrValues cfg.templates))} # Force Nix to track our templates
 
     ${cfg.package}/bin/matugen \
       ${command} \

--- a/module.nix
+++ b/module.nix
@@ -39,7 +39,9 @@ matugen: {
     builtins.mapAttrs (_: v: {
       mode = capitalize cfg.variant;
       input_path = builtins.toString v.input_path;
-      output_path = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
+      output_path = let
+          paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
+        in if builtins.length paths == 1 then builtins.head paths else paths;
     })
     cfg.templates;
 

--- a/module.nix
+++ b/module.nix
@@ -38,11 +38,8 @@ matugen: {
   sanitizedTemplates = builtins.mapAttrs (_: v: {
       mode = capitalize cfg.variant;
       input_path = toString v.input_path;
-      output_path = let
-        sanitize = p: builtins.replaceStrings ["$HOME"] ["~"] p;
-      in if builtins.isList v.output_path then map sanitize v.output_path else sanitize v.output_path;
-    }) cfg.templates;
-  
+      output_path = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
+    }) cfg.templates;  
   matugenConfig = configFormat.generate "matugen-config.toml" {
     config =
       {
@@ -53,7 +50,7 @@ matugen: {
   };
 
   # get matugen package
-  pkg = matugen.packages.${pkgs.system}.default;
+  pkg = matugen.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
   # takes in a source color string and returns the subcommand needed to generate
   # a color scheme using that color type.
@@ -78,7 +75,9 @@ matugen: {
     then "image ${cfg.wallpaper}"
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
-  themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {} ''
+  themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
+    buildInputs = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+  } ''
     mkdir -p $out
     cd $out
     export HOME=$(pwd)
@@ -137,7 +136,7 @@ in {
               type = either str (listOf str);
               description = "Path where the generated file will be written to";
               example = "~/.config/sytle.css";
-              # apply = val: if lib.isList val then val else [val];
+              apply = val: if lib.isList val then val else [val];
             };
             pre_hook = lib.mkOption {
               type = str;

--- a/module.nix
+++ b/module.nix
@@ -80,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    templatePaths = builtins.toString builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+    templatePaths = builtins.toString (builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates));
   } ''
     mkdir -p $out
     cd $out

--- a/module.nix
+++ b/module.nix
@@ -35,15 +35,14 @@ matugen: {
     lib.concatStrings [(lib.toUpper firstChar) restOfString];
 
   # don't use ~, use $HOME
-  sanitizedTemplates =
-    builtins.mapAttrs (_: v: {
-      input_path = builtins.toString v.input_path;
+  sanitizedTemplates = builtins.mapAttrs (_: v: {
+      mode = capitalize cfg.variant;
+      input_path = toString v.input_path;
       output_path = let
-          paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
-        in if builtins.length paths == 1 then builtins.head paths else paths;
-    })
-    cfg.templates;
-
+        sanitize = p: builtins.replaceStrings ["$HOME"] ["~"] p;
+      in if builtins.isList v.output_path then map sanitize v.output_path else sanitize v.output_path;
+    });
+  
   matugenConfig = configFormat.generate "matugen-config.toml" {
     config =
       {

--- a/module.nix
+++ b/module.nix
@@ -37,7 +37,7 @@ matugen: {
   # don't use ~, use $HOME
   sanitizedTemplates =
     builtins.mapAttrs (_: v: {
-      input_path = builtins.toString v.input_path;
+      input_path = v.input_path;
       output_path = let
           paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
         in if builtins.length paths == 1 then builtins.head paths else paths;

--- a/module.nix
+++ b/module.nix
@@ -37,7 +37,6 @@ matugen: {
   # don't use ~, use $HOME
   sanitizedTemplates =
     builtins.mapAttrs (_: v: {
-      mode = capitalize cfg.variant;
       input_path = builtins.toString v.input_path;
       output_path = let
           paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;

--- a/module.nix
+++ b/module.nix
@@ -41,7 +41,7 @@ matugen: {
       output_path = let
         sanitize = p: builtins.replaceStrings ["$HOME"] ["~"] p;
       in if builtins.isList v.output_path then map sanitize v.output_path else sanitize v.output_path;
-    });
+    }) cfg.templates;
   
   matugenConfig = configFormat.generate "matugen-config.toml" {
     config =

--- a/module.nix
+++ b/module.nix
@@ -35,11 +35,15 @@ matugen: {
     lib.concatStrings [(lib.toUpper firstChar) restOfString];
 
   # don't use ~, use $HOME
-  sanitizedTemplates = builtins.mapAttrs (_: v: {
-      mode = capitalize cfg.variant;
-      input_path = toString v.input_path;
-      output_path = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
-    }) cfg.templates;  
+  sanitizedTemplates =
+    builtins.mapAttrs (_: v: {
+      input_path = builtins.toString v.input_path;
+      output_path = let
+          paths = map (p: builtins.replaceStrings ["$HOME"] ["~"] p) v.output_path;
+        in if builtins.length paths == 1 then builtins.head paths else paths;
+    })
+    cfg.templates;
+
   matugenConfig = configFormat.generate "matugen-config.toml" {
     config =
       {
@@ -50,7 +54,7 @@ matugen: {
   };
 
   # get matugen package
-  pkg = matugen.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  pkg = matugen.packages.${pkgs.system}.default;
 
   # takes in a source color string and returns the subcommand needed to generate
   # a color scheme using that color type.
@@ -76,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    buildInputs = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
   } ''
     mkdir -p $out
     cd $out

--- a/module.nix
+++ b/module.nix
@@ -80,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    buildInputs = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
   } ''
     mkdir -p $out
     cd $out

--- a/module.nix
+++ b/module.nix
@@ -80,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+    buildInputs = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
   } ''
     mkdir -p $out
     cd $out

--- a/module.nix
+++ b/module.nix
@@ -137,7 +137,7 @@ in {
               type = either str (listOf str);
               description = "Path where the generated file will be written to";
               example = "~/.config/sytle.css";
-              apply = val: if lib.isList val then val else [val];
+              # apply = val: if lib.isList val then val else [val];
             };
             pre_hook = lib.mkOption {
               type = str;

--- a/module.nix
+++ b/module.nix
@@ -80,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    templatePaths = builtins.toString (builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates));
+    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
   } ''
     mkdir -p $out
     cd $out

--- a/module.nix
+++ b/module.nix
@@ -80,7 +80,7 @@ matugen: {
     else "color ${sourceColorTypeMatcher cfg.source_color} \"${cfg.source_color}\"";
 
   themePackage = builtins.trace command (pkgs.runCommandLocal "matugen-themes-${cfg.variant}" {
-    templatePaths = builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
+    templatePaths = builtins.toString builtins.attrValues (builtins.mapAttrs (_: v: v.input_path) cfg.templates);
   } ''
     mkdir -p $out
     cd $out


### PR DESCRIPTION
Fixes #278. This change made Nix make templates a dependency of matugen derivation, and thus made flake module fully usable.