### PR TITLE
feat: add smart scheme variant type and smart mode

### DIFF
--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -245,7 +245,11 @@ pub fn get_source_color_from_image(
     Ok(ranked[selection])
 }
 
-pub fn get_scored_colors_from_image(path: &str, filter_type: FilterType, fallback_color: Option<Argb>) -> Result<Vec<Argb>, Report> {
+pub fn get_scored_colors_from_image(
+    path: &str,
+    filter_type: FilterType,
+    fallback_color: Option<Argb>,
+) -> Result<Vec<Argb>, Report> {
     let mut original = ImageReader::open(path)?;
     let image = original.resize(112, 112, filter_type);
     let pixels: Vec<Argb> = image
@@ -260,7 +264,12 @@ pub fn get_scored_colors_from_image(path: &str, filter_type: FilterType, fallbac
         .color_to_count
         .retain(|&argb, _| Cam16::from(argb).chroma >= 5.0);
 
-    Ok(Score::score(&result.color_to_count, None, fallback_color, None))
+    Ok(Score::score(
+        &result.color_to_count,
+        None,
+        fallback_color,
+        None,
+    ))
 }
 
 pub fn select_source_color_from_ranks(

--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -2,7 +2,7 @@ use dialoguer::Select;
 use material_colors::{
     blend::harmonize,
     color::{Argb, Lab},
-    dynamic_color::{DynamicScheme, MaterialDynamicColors},
+    dynamic_color::{DynamicScheme, MaterialDynamicColors, Variant as MaterialColorsVariant},
     hct::Cam16,
     image::{FilterType, ImageReader},
     quantize::{Quantizer, QuantizerCelebi},
@@ -359,11 +359,10 @@ pub fn generate_dynamic_scheme(
     is_dark: bool,
     contrast_level: Option<f64>,
 ) -> DynamicScheme {
-    if let Some(var) = scheme_type.as_material_colors_variant() {
-        DynamicScheme::by_variant(source_color, &var, is_dark, contrast_level)
-    } else {
-        unreachable!()
-    }
+    let var = scheme_type
+        .as_material_colors_variant()
+        .unwrap_or(MaterialColorsVariant::TonalSpot);
+    DynamicScheme::by_variant(source_color, &var, is_dark, contrast_level)
 }
 
 pub fn make_custom_color(

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -119,7 +119,7 @@ pub fn generate_schemes_and_theme(
                 scheme_dark,
                 scheme_light,
                 &config_file.config.custom_colors,
-                args.r#type,
+                scheme_type,
                 &contrast,
                 &args.lightness_dark,
                 &args.lightness_light,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use material_colors::theme::ThemeBuilder;
 use serde_json::Value;
 
 mod helpers;
+mod smart_scheme;
 pub mod template;
 mod util;
 mod wallpaper;
@@ -20,11 +21,12 @@ use crate::{
         apply_opacity_to_schemes, generate_schemes_and_theme, get_syntax, json_from_file,
         merge_json, merge_json_source, parse_fallback_color,
     },
-    scheme::SchemeTypes,
+    scheme::{SchemeTypes, SchemesEnum},
     template::get_absolute_path,
     util::arguments::FilterType,
 };
 use helpers::{set_wallpaper, setup_logging};
+use smart_scheme::SmartOpts;
 use template::TemplateFile;
 
 use crate::{
@@ -43,10 +45,7 @@ pub mod parser;
 pub mod scheme;
 pub mod template_util;
 
-use crate::{
-    parser::Engine,
-    scheme::{Schemes, SchemesEnum},
-};
+use crate::{parser::Engine, scheme::Schemes};
 
 use material_colors::{color::Argb, theme::Theme};
 
@@ -58,6 +57,8 @@ pub struct State {
     pub theme: Option<Theme>,
     pub schemes: Option<Schemes>,
     pub default_scheme: SchemesEnum,
+    pub resolved_type: SchemeTypes,
+    pub smart_variant: SchemeTypes,
     pub image_hash: ImageCache,
     pub loaded_cache: bool,
     pub base16: Option<Schemes>,
@@ -73,21 +74,82 @@ impl State {
 
         config_file.parse_cli_overrides(&args);
 
-        let image_cache = ImageCache::new(
-            &args.source,
-            args.r#type,
-            args.contrast.or(config_file.config.contrast),
-            args.lightness_dark,
-            args.lightness_light,
-        );
+        let effective_mode = args.mode.unwrap_or(SchemesEnum::Dark);
+        let effective_type = args.r#type;
 
         let mut loaded_cache = false;
 
         let caching_enabled = config_file.config.caching.unwrap_or(false) && args.source.is_image();
 
-        let default_scheme = args
-            .mode
-            .ok_or_else(|| Report::msg("Something went wrong while parsing the mode"))?;
+        let any_template_smart = config_file
+            .templates
+            .values()
+            .any(|t| matches!(t.r#type, Some(SchemeTypes::SchemeSmart)));
+
+        let smart_requested = matches!(effective_mode, SchemesEnum::Smart)
+            || matches!(effective_type, SchemeTypes::SchemeSmart)
+            || any_template_smart;
+
+        let smart_opts: Option<SmartOpts> = if smart_requested {
+            if !args.source.is_image() {
+                warn!(
+                    "Smart scheme needs an image source, got <yellow>{:?}</>. Falling back to defaults.",
+                    args.source
+                );
+                None
+            } else {
+                let image_path = match &args.source {
+                    Source::Image { path } => path,
+                    _ => unreachable!(),
+                };
+                match smart_scheme::get_smart_opts(std::path::Path::new(image_path)) {
+                    Ok(opts) => Some(opts),
+                    Err(e) => {
+                        warn!(
+                            "Smart scheme detection failed: <yellow>{}</>. Falling back to defaults.",
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+        } else {
+            None
+        };
+
+        let smart_variant = smart_opts
+            .as_ref()
+            .map(|o| o.variant)
+            .unwrap_or(SchemeTypes::SchemeTonalSpot);
+
+        let default_scheme = match effective_mode {
+            SchemesEnum::Smart => smart_opts
+                .as_ref()
+                .map(|o| o.mode)
+                .unwrap_or(SchemesEnum::Dark),
+            other => other,
+        };
+
+        let resolved_type = match effective_type {
+            SchemeTypes::SchemeSmart => smart_opts
+                .as_ref()
+                .map(|o| o.variant)
+                .unwrap_or(SchemeTypes::SchemeTonalSpot),
+            other => other,
+        };
+
+        let image_cache = ImageCache::new(
+            &args.source,
+            resolved_type,
+            args.contrast.or(config_file.config.contrast),
+            args.lightness_dark,
+            args.lightness_light,
+        );
+
+        info!(
+            "Scheme: mode=<b><cyan>{}</>, variant=<b><cyan>{:?}</>",
+            default_scheme, resolved_type
+        );
 
         if let Source::Image { path } = &args.source {
             if args.show_source_colors.is_some_and(|x| x) {
@@ -107,6 +169,8 @@ impl State {
                     theme: None,
                     schemes: None,
                     default_scheme,
+                    resolved_type,
+                    smart_variant,
                     image_hash: image_cache,
                     loaded_cache,
                     base16: None,
@@ -132,14 +196,14 @@ impl State {
                             "<d>The cache in <yellow><b>{}</><d> doesn't exist.</>",
                             image_cache.get_path().display()
                         );
-                        generate_schemes_and_theme(&args, &config_file, args.r#type)?
+                        generate_schemes_and_theme(&args, &config_file, resolved_type)?
                     } else {
                         return Err(e.wrap_err("Couldn't load the cache file").suggestion("You may need to regenerate your cache if coming from v3.1.0 and lower."));
                     }
                 }
             }
         } else {
-            generate_schemes_and_theme(&args, &config_file, args.r#type)?
+            generate_schemes_and_theme(&args, &config_file, resolved_type)?
         };
 
         apply_opacity_to_schemes(&mut base16, args.opacity);
@@ -153,6 +217,8 @@ impl State {
             theme,
             schemes,
             default_scheme,
+            resolved_type,
+            smart_variant,
             image_hash: image_cache,
             loaded_cache,
             base16,
@@ -258,6 +324,7 @@ impl State {
         let is_dark_mode = match self.default_scheme {
             SchemesEnum::Dark => true,
             SchemesEnum::Light => false,
+            SchemesEnum::Smart => unreachable!("default_scheme is resolved before storage"),
         };
 
         Ok(serde_json::json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ mod wallpaper;
 
 use crate::{
     cache::ImageCache,
-    color::{base16::Backend, color::{Source, get_filter, get_scored_colors_from_image}},
+    color::{
+        base16::Backend,
+        color::{get_filter, get_scored_colors_from_image, Source},
+    },
     helpers::{
         apply_opacity_to_schemes, generate_schemes_and_theme, get_syntax, json_from_file,
         merge_json, merge_json_source, parse_fallback_color,

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -25,6 +25,7 @@ pub enum SchemeTypes {
     SchemeRainbow,
     SchemeTonalSpot,
     SchemeVibrant,
+    SchemeSmart,
 }
 
 impl SchemeTypes {
@@ -40,6 +41,7 @@ impl SchemeTypes {
             SchemeTypes::SchemeRainbow => Some(MaterialColorsVariant::Rainbow),
             SchemeTypes::SchemeTonalSpot => Some(MaterialColorsVariant::TonalSpot),
             SchemeTypes::SchemeVibrant => Some(MaterialColorsVariant::Vibrant),
+            SchemeTypes::SchemeSmart => None,
             _ => None,
         }
     }
@@ -80,6 +82,7 @@ impl Schemes {
 pub enum SchemesEnum {
     Light,
     Dark,
+    Smart,
 }
 
 impl fmt::Display for SchemesEnum {
@@ -87,6 +90,7 @@ impl fmt::Display for SchemesEnum {
         let str = match self {
             SchemesEnum::Light => "light",
             SchemesEnum::Dark => "dark",
+            SchemesEnum::Smart => "smart",
         };
 
         write!(f, "{str}")

--- a/src/smart_scheme.rs
+++ b/src/smart_scheme.rs
@@ -1,0 +1,155 @@
+use std::path::Path;
+
+use color_eyre::Report;
+use image::{imageops::FilterType, DynamicImage, GenericImageView, ImageReader};
+use material_colors::hct::Hct;
+
+use crate::color::format::argb_from_rgb;
+use crate::scheme::{SchemeTypes, SchemesEnum};
+use colorsys::Rgb;
+
+pub struct SmartOpts {
+    pub mode: SchemesEnum,
+    pub variant: SchemeTypes,
+}
+
+fn calc_colorfulness(image: &DynamicImage) -> f64 {
+    let rgb_image = image.to_rgb8();
+    let pixels = rgb_image.pixels();
+
+    let mut rg_sum = 0.0;
+    let mut yb_sum = 0.0;
+    let mut rg_sq_sum = 0.0;
+    let mut yb_sq_sum = 0.0;
+    let mut count = 0u64;
+
+    for pixel in pixels {
+        let r = pixel[0] as f64;
+        let g = pixel[1] as f64;
+        let b = pixel[2] as f64;
+
+        let rg = (r - g).abs();
+        let yb = (0.5 * (r + g) - b).abs();
+
+        rg_sum += rg;
+        yb_sum += yb;
+        rg_sq_sum += rg * rg;
+        yb_sq_sum += yb * yb;
+        count += 1;
+    }
+
+    if count == 0 {
+        return 0.0;
+    }
+
+    let mean_rg = rg_sum / count as f64;
+    let mean_yb = yb_sum / count as f64;
+    let variance_rg = (rg_sq_sum / count as f64) - (mean_rg * mean_rg);
+    let variance_yb = (yb_sq_sum / count as f64) - (mean_yb * mean_yb);
+    let std_rg = variance_rg.sqrt().max(0.0);
+    let std_yb = variance_yb.sqrt().max(0.0);
+
+    (std_rg.powi(2) + std_yb.powi(2)).sqrt() + 0.3 * (mean_rg.powi(2) + mean_yb.powi(2)).sqrt()
+}
+
+fn detect_variant(colorfulness: f64) -> SchemeTypes {
+    match colorfulness {
+        ..6.0 => SchemeTypes::SchemeMonochrome,
+        6.0..20.0 => SchemeTypes::SchemeNeutral,
+        20.0..70.0 => SchemeTypes::SchemeTonalSpot,
+        _ => SchemeTypes::SchemeVibrant,
+    }
+}
+
+fn detect_mode(image: &DynamicImage) -> SchemesEnum {
+    let resized = image.resize_exact(1, 1, FilterType::Lanczos3);
+    let pixel = resized.get_pixel(0, 0);
+
+    let rgb = Rgb::from((pixel[0] as f64, pixel[1] as f64, pixel[2] as f64));
+    let argb = argb_from_rgb(&rgb);
+    let hct: Hct = argb.into();
+
+    if hct.get_tone() > 60.0 {
+        SchemesEnum::Light
+    } else {
+        SchemesEnum::Dark
+    }
+}
+
+pub fn get_smart_opts(image_path: &Path) -> Result<SmartOpts, Report> {
+    let img = ImageReader::open(image_path)?.decode()?;
+    let thumb = img.thumbnail(128, 128);
+
+    let mode = detect_mode(&thumb);
+    let colorfulness = calc_colorfulness(&thumb);
+    let variant = detect_variant(colorfulness);
+
+    Ok(SmartOpts { mode, variant })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_colorfulness_grayscale() {
+        let img = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            128,
+            128,
+            image::Rgb([128, 128, 128]),
+        ));
+        let score = calc_colorfulness(&img);
+        assert!(
+            score < 1.0,
+            "Grayscale image should have near-zero colorfulness, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_colorfulness_colorful() {
+        let mut img_buf = image::RgbImage::new(128, 128);
+        for y in 0..128 {
+            for x in 0..128 {
+                let r = ((x * 2) % 256) as u8;
+                let g = ((y * 2) % 256) as u8;
+                let b = (((x + y) * 2) % 256) as u8;
+                img_buf.put_pixel(x, y, image::Rgb([r, g, b]));
+            }
+        }
+        let img = DynamicImage::ImageRgb8(img_buf);
+        let score = calc_colorfulness(&img);
+        assert!(
+            score > 20.0,
+            "Colorful gradient should score high, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_detect_variant_boundaries() {
+        assert!(matches!(detect_variant(0.0), SchemeTypes::SchemeMonochrome));
+        assert!(matches!(detect_variant(6.0), SchemeTypes::SchemeNeutral));
+        assert!(matches!(detect_variant(20.0), SchemeTypes::SchemeTonalSpot));
+        assert!(matches!(detect_variant(70.0), SchemeTypes::SchemeVibrant));
+        assert!(matches!(detect_variant(100.0), SchemeTypes::SchemeVibrant));
+    }
+
+    #[test]
+    fn test_detect_mode_dark() {
+        let img = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            128,
+            128,
+            image::Rgb([20, 20, 30]),
+        ));
+        assert!(matches!(detect_mode(&img), SchemesEnum::Dark));
+    }
+
+    #[test]
+    fn test_detect_mode_light() {
+        let img = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            128,
+            128,
+            image::Rgb([240, 240, 250]),
+        ));
+        assert!(matches!(detect_mode(&img), SchemesEnum::Light));
+    }
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-use std::{collections::HashMap, path::Path, process::Stdio, str};
+use std::{collections::HashMap, path::Path, str};
 
 use std::{
     fs::{create_dir_all, read_to_string, OpenOptions},
@@ -102,6 +102,7 @@ impl TemplateFile<'_> {
                 match self.state.default_scheme {
                     SchemesEnum::Light => &input_path_mode.light,
                     SchemesEnum::Dark => &input_path_mode.dark,
+                    SchemesEnum::Smart => unreachable!("default_scheme is resolved before storage"),
                 }
             } else {
                 &template.input_path
@@ -162,7 +163,11 @@ impl TemplateFile<'_> {
                 continue;
             }
 
-            if let Some(scheme_type) = template.r#type {
+            let scheme_type = template.r#type.map(|t| match t {
+                SchemeTypes::SchemeSmart => self.state.smart_variant,
+                other => other,
+            });
+            if let Some(scheme_type) = scheme_type {
                 if let Some(entry) = self.scheme_cache.get(&scheme_type) {
                     change_scheme_type(
                         self.engine,

--- a/src/template_util/template.rs
+++ b/src/template_util/template.rs
@@ -79,6 +79,7 @@ pub fn generate_single_color(
     let default_scheme_color = match default_scheme {
         SchemesEnum::Light => color_light,
         SchemesEnum::Dark => color_dark,
+        SchemesEnum::Smart => unreachable!("default_scheme is resolved before storage"),
     };
 
     if field == "source_color" {

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -127,6 +127,7 @@ pub fn format_schemes(
         let default_hex = match default_scheme {
             SchemesEnum::Dark => dark_hex.clone(),
             SchemesEnum::Light => light_hex.clone(),
+            SchemesEnum::Smart => unreachable!("default_scheme is resolved before storage"),
         };
 
         let mut schemes = Map::new();


### PR DESCRIPTION
Adds new `--type scheme-smart` and `--mode smart`
addresses - https://github.com/InioX/matugen/issues/300

I have been personally using this change on my own branch and I think its quite good now.
The colorfulness and lightness calculation is a direct copy of the example that was shown in https://github.com/InioX/matugen/issues/300

Although made some changes to the colorfulness range:
```
match colorfulness {
    ..6.0 => SchemeTypes::SchemeMonochrome,
    6.0..20.0 => SchemeTypes::SchemeNeutral,
    20.0..70.0 => SchemeTypes::SchemeTonalSpot,
    _ => SchemeTypes::SchemeVibrant,
}
```
Obviously I left tonal spot with the largest range since its more expected that most wallpapers should use tonal spot scheme variant.

For the lightness range I didn't make any change compared to the example in https://github.com/InioX/matugen/issues/300 because I think it looks quite good and works perfectly with some dark/light wallpapers as you can see here:

https://github.com/user-attachments/assets/74f30026-8cc5-4f57-984d-2bfb80756396

And here is what it looks like testing type variants for monochrome, neutral and stuff:

https://github.com/user-attachments/assets/bda5a4ab-f344-457b-8eaf-6d92bc585591

Both of the range for colorfulness and lightness are pretty much hard coded and not configurable, because I thought it made more sense that way anyways but idk, what do you think about it?

