### PR TITLE
fix: (nix) update deprecated `system` usage

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -53,7 +53,7 @@ matugen: {
   };
 
   # get matugen package
-  pkg = matugen.packages.${pkgs.system}.default;
+  pkg = matugen.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
   # takes in a source color string and returns the subcommand needed to generate
   # a color scheme using that color type.


### PR DESCRIPTION
`system` is deprecated since NixOS 25.11. Use `stdenv.hostPlatform.system` instead.