### PR TITLE
Add missing `SchemeSmart` variant to example config

### DIFF
--- a/example/config.toml
+++ b/example/config.toml
@@ -74,7 +74,8 @@ output_path = "./a/colors-generated.whatever-extension"
 index = 1
 
 # Defaults to the type from CLI if unspecified.
-# One of `SchemeContent`, `SchemeExpressive`, `SchemeFidelity`, `SchemeFruitSalad`, `SchemeMonochrome`, `SchemeNeutral`, `SchemeRainbow`, `SchemeTonalSpot`, `SchemeVibrant`
+# One of `SchemeContent`, `SchemeExpressive`, `SchemeFidelity`, `SchemeFruitSalad`, `SchemeMonochrome`,
+# `SchemeNeutral`, `SchemeRainbow`, `SchemeTonalSpot`, `SchemeVibrant`, `SchemeSmart`
 type = "SchemeExpressive"
 
 # For testing of the `--continue-on-error` flag


### PR DESCRIPTION
This PR adds the smart scheme variant introduced in #310 to the example config.toml

Also adds a line break for readability