### PR TITLE
fix(nix): allow output_path to be used as a string in Nix module

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -151,7 +151,7 @@ in
               type = either str (listOf str);
               description = "Path where the generated file will be written to";
               example = "~/.config/sytle.css";
-              apply = val: if lib.isList val then val else [ val ];
+              apply = lib.id;
             };
             pre_hook = lib.mkOption {
               type = str;


### PR DESCRIPTION
## Problem

The Nix module currently applies a transformation that converts any output_path value into a list before passing it to Matugen:

```
apply = val: if lib.isList val then val else [ val ];
```

However, Matugen's TOML configuration expects output_path to be a plain string, not a list.
In [Docs](https://iniox.github.io#matugen/configuration/adding-templates)

```
[templates.test] # First way of adding template
input_path = '~/.config/example/template.css'
output_path = '~/.config/example'
```

This problem causes Matugen to fail with the error:
```
Failed to get the input and output paths from hashmap
```
As a result, users who follow the natural output_path = "file.yaml" syntax encounter build failures.

## Fix

Remove the forced conversion and pass the value as-is using lib.id:

```
apply = lib.id;
```

## Testing

Verified locally on NixOS.