### PR TITLE
fix: panics, grayscale bug, duplicate filter, and process::exit in library code

### DIFF
--- a/src/filters/colortransform.rs
+++ b/src/filters/colortransform.rs
@@ -65,7 +65,7 @@ pub(crate) fn grayscale(
             Ok(FilterReturnType::Rgb(color))
         }
         FilterReturnType::Hsl(mut color) => {
-            color.invert();
+            color.grayscale_simple();
             Ok(FilterReturnType::Hsl(color))
         }
         FilterReturnType::Bool(_) => Err(FilterError::ColorFilterOnBool),

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,20 +376,6 @@ impl State {
                 /// </md-card>
                 "set_green" => crate::filters::set_green,
 
-                /// <p>Sets the blue channel of a color</p>
-                ///
-                /// <p><strong>Arguments:</strong></p>
-                ///
-                /// <ul>
-                ///     <li><code>Int</code> - the blue channel value (0-255)</li>
-                /// </ul>
-
-                /// <p><strong>Example:</strong></p>
-                /// <md-card class="code-card">
-                ///     <pre class="code-block"><code class="language-bash">{{ "#000000" | to_color | set_blue: 255 }}</code></pre>
-                /// </md-card>
-                "set_blue" => crate::filters::set_blue,
-
                 /// <p>Sets the alpha channel of a color</p>
                 ///
                 /// <p><strong>Arguments:</strong></p>

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -150,6 +150,8 @@ pub enum FilterError {
     },
     #[error("You should not use the set_alpha filter with a format that doesn't have an alpha channel. Consider using one of these formats instead: [{replacement}]")]
     SetAlphaOnNonAlphaFormat { replacement: &'static str },
+    #[error("Cannot convert Null value in filter")]
+    NullValue,
 }
 
 impl Error {
@@ -212,6 +214,7 @@ impl FilterError {
             FilterError::UnexpectedStringValue { .. } => "UnexpectedStringValue",
             FilterError::InvalidFormatString { .. } => "InvalidFormatString",
             FilterError::SetAlphaOnNonAlphaFormat { .. } => "SetAlphaOnNonAlphaFormat",
+            FilterError::NullValue => "NullValue",
         }
     }
 }

--- a/src/parser/filters/filtertype.rs
+++ b/src/parser/filters/filtertype.rs
@@ -120,7 +120,7 @@ impl From<Value> for FilterReturnType {
             Value::Bool(boolean) => Self::Bool(boolean),
             Value::Map(_hash_map) => panic!("Cant convert map to FilterReturnType"),
             Value::Array(_array) => panic!("Cant convert Array to String"),
-            Value::Null => todo!(),
+            Value::Null => FilterReturnType::String(String::new()),
             Value::LazyColor { color, scheme: _ } => FilterReturnType::from(Value::Color(color)),
         }
     }
@@ -134,10 +134,10 @@ impl From<&Value> for FilterReturnType {
             Value::Float(v) => v.into(),
             Value::Color(v) => v.into(),
             Value::HslColor(v) => v.into(),
-            Value::Bool(v) => v.into(),
+            Value::Bool(v) => Self::Bool(*v),
             Value::Map(_hash_map) => panic!("Cant convert map to FilterReturnType"),
             Value::Array(_array) => panic!("Cant convert Array to String"),
-            Value::Null => todo!(),
+            Value::Null => FilterReturnType::String(String::new()),
             Value::LazyColor { color, scheme: _ } => color.into(),
         }
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -376,7 +376,9 @@ pub fn format_hook(
                 for err in errors {
                     err.emit(&engine)?;
                 }
-                return Err(color_eyre::eyre::eyre!("Failed to compile compare_to template"));
+                return Err(color_eyre::eyre::eyre!(
+                    "Failed to compile compare_to template"
+                ));
             }
         };
         let closest_color = get_closest_color(compare, &res)?;

--- a/src/template.rs
+++ b/src/template.rs
@@ -376,7 +376,7 @@ pub fn format_hook(
                 for err in errors {
                     err.emit(&engine)?;
                 }
-                std::process::exit(1);
+                return Err(color_eyre::eyre::eyre!("Failed to compile compare_to template"));
             }
         };
         let closest_color = get_closest_color(compare, &res)?;
@@ -392,7 +392,7 @@ pub fn format_hook(
             for err in errors {
                 err.emit(&engine)?;
             }
-            std::process::exit(1);
+            return Err(color_eyre::eyre::eyre!("Failed to compile hook template"));
         }
     };
 


### PR DESCRIPTION
## Changes

- **Replace `todo!()` panics in `FilterReturnType` conversion** — `Value::Null` now coerces to an empty string instead of panicking at runtime
- **Fix grayscale filter on HSL colors** — was calling `invert()` instead of `grayscale_simple()`
- **Remove duplicate `set_blue` filter registration** — registered twice in `main.rs`, second overwrote first
- **Replace `std::process::exit(1)` with proper error propagation** — `format_hook` now returns `Err` instead of bypassing Drop

## Testing

All 6 existing tests pass. No new warnings introduced.